### PR TITLE
Sørger for at man får et token via loginservice

### DIFF
--- a/mock/authentication.js
+++ b/mock/authentication.js
@@ -1,3 +1,5 @@
+import minSideTjenester from "./bundle/min-side-tjenester";
+
 export default [
     {
       url: "/tms-min-side-proxy/login/status",
@@ -10,12 +12,11 @@ export default [
       },
     },
     {
-      url: "/innloggingsstatus",
+      url: "/dittnav-api/authPing",
       method: "get",
-      response: () => {
-        return {
-          authenticated: true,
-        };
+      rawResponse: async (req, res) => {
+        res.statusCode = 401
+        res.end()
       },
     },
 ];

--- a/mock/authentication.js
+++ b/mock/authentication.js
@@ -1,5 +1,3 @@
-import minSideTjenester from "./bundle/min-side-tjenester";
-
 export default [
     {
       url: "/tms-min-side-proxy/login/status",

--- a/mock/authentication.js
+++ b/mock/authentication.js
@@ -14,9 +14,10 @@ export default [
     {
       url: "/dittnav-api/authPing",
       method: "get",
-      rawResponse: async (req, res) => {
-        res.statusCode = 401
-        res.end()
+      response: () => {
+        return {
+          ping: "pong",
+        };
       },
     },
 ];

--- a/src/api/api.jsx
+++ b/src/api/api.jsx
@@ -1,6 +1,13 @@
+class FetchError extends Error {
+  constructor(response, message) {
+    super(message);
+    this.response = response;
+  }
+}
+
 const checkResponse = (response) => {
   if (!response.ok) {
-    throw new Error("Fetch request failed");
+    throw new FetchError(response, "Fetch request failed");
   }
 };
 

--- a/src/components/authentication/Authentication.jsx
+++ b/src/components/authentication/Authentication.jsx
@@ -10,7 +10,7 @@ const Authentication = ({ children }) => {
   const { data: legacyStatus, isLoadingLegacyStatus } = useQuery(authenticationUrl, fetcher, {
     enabled: !isLoading,
     onError: (error) => {
-      if (error.request.status === 401) {
+      if (error.response.status === 401) {
         redirectToLoginService();
       }
     },

--- a/src/components/authentication/Authentication.jsx
+++ b/src/components/authentication/Authentication.jsx
@@ -8,9 +8,9 @@ import ContentLoader from "../loader/ContentLoader";
 const Authentication = ({ children }) => {
   const { data: status, isLoading, isError } = useQuery(`${minSideProxyUrl}/login/status`, fetcher);
   const { data: legacyStatus, isLoadingLegacyStatus } = useQuery(authenticationUrl, fetcher, {
-    onError: async (error) => {
-      console.log(error.request);
-      if (error.request.status === 401 && !isLoading) {
+    enabled: !isLoading,
+    onError: (error) => {
+      if (error.request.status === 401) {
         redirectToLoginService();
       }
     },

--- a/src/components/authentication/Authentication.jsx
+++ b/src/components/authentication/Authentication.jsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { useQuery } from "react-query";
 import redirectToIdPorten, { redirectToLoginService } from "../../api/redirect";
-import { authenticationUrl, minSideProxyUrl } from "../../urls";
+import { legacyAuthenticationUrl, authenticationUrl } from "../../urls";
 import { fetcher } from "../../api/api";
 import ContentLoader from "../loader/ContentLoader";
 
 const Authentication = ({ children }) => {
-  const { data: status, isLoading, isError } = useQuery(`${minSideProxyUrl}/login/status`, fetcher);
-  const { data: legacyStatus, isLoadingLegacyStatus } = useQuery(authenticationUrl, fetcher, {
-    enabled: !isLoading,
+  const { data: status, isLoadingStatus, isError } = useQuery(authenticationUrl, fetcher);
+  const { data: legacyStatus, isLoadingLegacyStatus } = useQuery(legacyAuthenticationUrl, fetcher, {
+    enabled: !isLoadingStatus,
     onError: (error) => {
       if (error.response.status === 401) {
         redirectToLoginService();
@@ -16,7 +16,7 @@ const Authentication = ({ children }) => {
     },
   });
 
-  if (isLoading || isLoadingLegacyStatus) {
+  if (isLoadingStatus || isLoadingLegacyStatus) {
     return <ContentLoader size="2xlarge">...</ContentLoader>;
   }
 

--- a/src/components/authentication/Authentication.jsx
+++ b/src/components/authentication/Authentication.jsx
@@ -1,25 +1,26 @@
 import React from "react";
 import { useQuery } from "react-query";
 import redirectToIdPorten, { redirectToLoginService } from "../../api/redirect";
-import { innloggingsstatusUrl, minSideProxyUrl } from "../../urls";
+import { authenticationUrl, minSideProxyUrl } from "../../urls";
 import { fetcher } from "../../api/api";
 import ContentLoader from "../loader/ContentLoader";
 
 const Authentication = ({ children }) => {
   const { data: status, isLoading, isError } = useQuery(`${minSideProxyUrl}/login/status`, fetcher);
-  const { data: innloggingsstatus, isLoadingInnloggingsstatus } = useQuery(innloggingsstatusUrl, fetcher);
+  const { data: legacyStatus, isLoadingLegacyStatus } = useQuery(authenticationUrl, fetcher, {
+    onError: async (error) => {
+      if (error.request.status === 401 && !isLoading) {
+        redirectToLoginService();
+      }
+    },
+  });
 
-  if (isLoading || isLoadingInnloggingsstatus) {
+  if (isLoading || isLoadingLegacyStatus) {
     return <ContentLoader size="2xlarge">...</ContentLoader>;
   }
 
   if (!status?.authenticated || isError) {
     redirectToIdPorten();
-    return null;
-  }
-
-  if (innloggingsstatus?.authenticated === false && status?.authenticated === true) {
-    redirectToLoginService();
     return null;
   }
 

--- a/src/components/authentication/Authentication.jsx
+++ b/src/components/authentication/Authentication.jsx
@@ -9,6 +9,7 @@ const Authentication = ({ children }) => {
   const { data: status, isLoading, isError } = useQuery(`${minSideProxyUrl}/login/status`, fetcher);
   const { data: legacyStatus, isLoadingLegacyStatus } = useQuery(authenticationUrl, fetcher, {
     onError: async (error) => {
+      console.log(error.request);
       if (error.request.status === 401 && !isLoading) {
         redirectToLoginService();
       }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,9 +5,21 @@ import Authentication from "./components/authentication/Authentication";
 import { QueryClient, QueryClientProvider } from "react-query";
 import "./main.css";
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+      cacheTime: Infinity,
+      refetchOnWindowFocus: false,
+      refetchInterval: false,
+      refetchOnMount: false,
+    },
+  },
+});
+
 ReactDOM.render(
   <React.StrictMode>
-    <QueryClientProvider client={new QueryClient()}>
+    <QueryClientProvider client={queryClient}>
       <Authentication>
         <App />
       </Authentication>

--- a/src/urls.jsx
+++ b/src/urls.jsx
@@ -13,7 +13,7 @@ const MIN_SIDE_PROXY_URL = {
 };
 
 const AUTHENTICATION_URL = {
-  local: "http://localhost:3000/authPing",
+  local: "http://localhost:3000/dittnav-api/authPing",
   development: "https://person.dev.nav.no/dittnav-api/authPing",
   production: "https://person.nav.no/dittnav-api/authPing",
 };

--- a/src/urls.jsx
+++ b/src/urls.jsx
@@ -12,7 +12,7 @@ const MIN_SIDE_PROXY_URL = {
   production: "https://person.intern.nav.no/tms-min-side-proxy",
 };
 
-const AUTHENTICATION_URL = {
+const LEGACY_AUTHENTICATION_URL = {
   local: "http://localhost:3000/dittnav-api/authPing",
   development: "https://person.dev.nav.no/dittnav-api/authPing",
   production: "https://person.nav.no/dittnav-api/authPing",
@@ -33,5 +33,6 @@ const LOGINSERVICE_URL = {
 export const minSideUrl = MIN_SIDE_URL[getEnvironment()];
 export const minSideTjenesterUrl = MIN_SIDE_TJENESTER[getEnvironment()];
 export const minSideProxyUrl = MIN_SIDE_PROXY_URL[getEnvironment()];
-export const authenticationUrl = AUTHENTICATION_URL[getEnvironment()];
+export const authenticationUrl = `${MIN_SIDE_PROXY_URL[getEnvironment()]}/login/status`;
+export const legacyAuthenticationUrl = LEGACY_AUTHENTICATION_URL[getEnvironment()];
 export const loginserviceUrl = LOGINSERVICE_URL[getEnvironment()];

--- a/src/urls.jsx
+++ b/src/urls.jsx
@@ -12,6 +12,12 @@ const MIN_SIDE_PROXY_URL = {
   production: "https://person.intern.nav.no/tms-min-side-proxy",
 };
 
+const AUTHENTICATION_URL = {
+  local: "http://localhost:3000/authPing",
+  development: "https://person.dev.nav.no/person/dittnav-api/authPing",
+  production: "https://person.nav.no/person/dittnav-api/authPing",
+};
+
 const MIN_SIDE_TJENESTER = {
   local: "http://localhost:3000/tms-min-side-tjenester/bundle.js",
   development: "https://person.dev.nav.no/tms-min-side-tjenester/bundle.js",
@@ -24,14 +30,8 @@ const LOGINSERVICE_URL = {
   production: "https://loginservice.nav.no/login?level=Level3",
 };
 
-const INNLOGGINGSSTATUS_URL = {
-  local: "http://localhost:3000/innloggingsstatus",
-  development: "https://innloggingsstatus.dev.nav.no/person/innloggingsstatus/auth",
-  production: "https://www.nav.no/person/innloggingsstatus/auth",
-};
-
 export const minSideUrl = MIN_SIDE_URL[getEnvironment()];
 export const minSideTjenesterUrl = MIN_SIDE_TJENESTER[getEnvironment()];
 export const minSideProxyUrl = MIN_SIDE_PROXY_URL[getEnvironment()];
+export const authenticationUrl = AUTHENTICATION_URL[getEnvironment()];
 export const loginserviceUrl = LOGINSERVICE_URL[getEnvironment()];
-export const innloggingsstatusUrl = INNLOGGINGSSTATUS_URL[getEnvironment()];

--- a/src/urls.jsx
+++ b/src/urls.jsx
@@ -14,8 +14,8 @@ const MIN_SIDE_PROXY_URL = {
 
 const AUTHENTICATION_URL = {
   local: "http://localhost:3000/authPing",
-  development: "https://person.dev.nav.no/person/dittnav-api/authPing",
-  production: "https://person.nav.no/person/dittnav-api/authPing",
+  development: "https://person.dev.nav.no/dittnav-api/authPing",
+  production: "https://person.nav.no/dittnav-api/authPing",
 };
 
 const MIN_SIDE_TJENESTER = {


### PR DESCRIPTION
For å få et token via loginservice gjøres det et kall mot et auth endepunkt i dittnav-api for å sjekke om en bruker er autentisert. Denne koden kan fjernes når vi har gått over til å bruke token exchange.