### PR TITLE
PB-996: Gjør det mulig å velge språk med dekoratørens språkvelger

### DIFF
--- a/src/components/feilmelding/Feilmelding.jsx
+++ b/src/components/feilmelding/Feilmelding.jsx
@@ -1,14 +1,19 @@
 import React from "react";
 import { Alert } from "@navikt/ds-react";
 import "./Feilmelding.css";
+import useStore, { selectLanguage } from "../../store/store";
 
 const FeilMelding = () => {
-  const tekst =
-    "Vi har for øyeblikket tekniske problemer. Dette kan føre til at du ikke får opp all informasjon. Vennligst prøv igjen senere.";
+  const language = useStore(selectLanguage);
+
+  const tekst = {
+    nb: "Vi har for øyeblikket tekniske problemer. Dette kan føre til at du ikke får opp all informasjon. Vennligst prøv igjen senere.",
+    en: "We're having technical difficulties. Some information may not be available, please try again later.",
+  };
 
   return (
     <Alert variant="error" className="feilmelding">
-      {tekst}
+      {tekst[language]}
     </Alert>
   );
 };

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,8 +1,11 @@
 import React from "react";
 import FeilMelding from "../feilmelding/Feilmelding";
 import "./Layout.css";
+import { useLanguage } from "../../hooks/useLanguage";
 
 const Layout = ({ children, isError }) => {
+  useLanguage();
+
   return (
     <div className="layout">
       <main>

--- a/src/hooks/useLanguage.jsx
+++ b/src/hooks/useLanguage.jsx
@@ -1,0 +1,24 @@
+import { onLanguageSelect, setAvailableLanguages } from "@navikt/nav-dekoratoren-moduler";
+import { useEffect } from "react";
+import useStore, { selectSetLanguage } from "../store/store";
+
+export const useLanguage = () => {
+  const setLanguage = useStore(selectSetLanguage);
+
+  onLanguageSelect((language) => {
+    setLanguage(language.locale);
+  });
+
+  useEffect(() => {
+    setAvailableLanguages([
+      {
+        locale: "nb",
+        handleInApp: true,
+      },
+      {
+        locale: "en",
+        handleInApp: true,
+      },
+    ]);
+  }, []);
+};

--- a/src/store/store.jsx
+++ b/src/store/store.jsx
@@ -1,8 +1,14 @@
 import create from "zustand";
 
 export const selectIsError = (state) => state.isError;
+export const selectLanguage = (state) => state.language;
+export const selectSetLanguage = (state) => state.setLanguage;
 
 const actions = (set) => ({
+  setLanguage: (locale) =>
+    set({
+      language: locale,
+    }),
   setIsError: () =>
     set({
       isError: true,
@@ -10,6 +16,7 @@ const actions = (set) => ({
 });
 
 const useStore = create((set) => ({
+  language: "nb",
   isError: false,
   ...actions(set),
 }));


### PR DESCRIPTION
For å velge språk kan man trekke inn dekoratørens språkvelger og la den sette språkvalgett i en cookie. På denne måten blir det enkelt for andre mikrofrontends å sette språk, uten at man trenger å dele på state eller utveksle meldinger.

PB-996: Gjør det mulig å velge språk med dekoratøren språkvelger