### PR TITLE
Slår av etag caching

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,12 +1,13 @@
-const express = require('express');
-const logger = require('./logger');
-const path = require('path');
-const getHtmlWithDecorator = require('./dekorator');
-const basePath = '/minside';
-const buildPath = path.resolve(__dirname, '../dist');
+const express = require("express");
+const logger = require("./logger");
+const path = require("path");
+const getHtmlWithDecorator = require("./dekorator");
+const basePath = "/minside";
+const buildPath = path.resolve(__dirname, "../dist");
 const server = express();
 
-server.disable('x-powered-by');
+server.set("etag", false);
+server.disable("x-powered-by");
 
 server.use(basePath, express.static(buildPath, { index: false }));
 


### PR DESCRIPTION
Slår av etag caching for å se om det løser et problem for Arbeidsflate for innlogget arbeidssøker der eldre versjoner ligger cachet i browseren.