### PR TITLE
UXSignals widget for AiA

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1723632283415
+		"lastUpdateCheck": 1728374821820
 	}
 }

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/mock/server.ts
+++ b/mock/server.ts
@@ -4,7 +4,6 @@ import { cors } from "hono/cors";
 import manifest from "./data/microfrontend/manifest.json" assert { type: "json" };
 import navn from "./data/navn.json" assert { type: "json" };
 import selector from "./data/selector.json" assert { type: "json" };
-import sakstemaerEgne from "./data/sakstemaer-egne.json" assert { type: "json" };
 import varsler from "./data/varsler.json" assert { type: "json" };
 import utkast from "./data/utkast.json" assert { type: "json" };
 import utbetalinger from "./data/utbetalinger.json" assert { type: "json" };
@@ -98,6 +97,29 @@ api.get('/meldekort/bundle.js', (c) => {
       "Content-Type": "text/javascript",
     },
   });
+});
+
+api.get('/aia-backend/unleash', (c) => {
+  return c.json({
+    "aia.uxsignals": true
+  });
+});
+
+api.get("/aia-backend/arbeidssokerregisteret/v1/arbeidssoekerperioder", (c) => {
+  return c.json([
+    {
+      periodeId: "eb39f0ee-ddba-42a1-8ed3-590285b2e279",
+      startet: {
+        tidspunkt: "2024-03-14T12:29:10.926Z",
+        utfoertAv: {
+          type: "VEILEDER"
+        },
+        kilde: "paw-arbeidssoekerregisteret-inngang",
+        aarsak: "Er over 18 år, er bosatt i Norge etter Folkeregisterloven"
+      },
+      avsluttet: null
+    }
+  ]);
 });
 
 serve(api);

--- a/src/components/oversikt/urls.ts
+++ b/src/components/oversikt/urls.ts
@@ -29,9 +29,15 @@ const AKTIVITETSPLAN_URL = {
   dev: "https://aktivitetsplan.ekstern.dev.nav.no/",
   prod: "https://aktivitetsplan.nav.no/",
 };
+const AIA_BACKEND_URL = {
+  local: "http://localhost:3000/aia-backend",
+  dev: "https://www.intern.dev.nav.no/aia-backend",
+  prod: "https://www.nav.no/aia-backend",
+};
 
 export const meldekortUrl = MELDEKORT_URL[getEnvironmentClientSide()];
 export const dinOversiktUrl = `${SELECTOR_URL[getEnvironmentClientSide()]}/din-oversikt`;
 export const featureToggleUrl = `${MIN_SIDE_PROXY_URL[getEnvironmentClientSide()]}/featuretoggles`;
 export const dialogMedVeilederUrl = DIALOG_MED_VEILEDER_URL[getEnvironmentClientSide()];
 export const aktivitetsplanUrl = AKTIVITETSPLAN_URL[getEnvironmentClientSide()];
+export const aiaBackendUrl = AIA_BACKEND_URL[getEnvironmentClientSide()];

--- a/src/components/ux-signal/AiAUXSignals.tsx
+++ b/src/components/ux-signal/AiAUXSignals.tsx
@@ -24,7 +24,7 @@ async function sjekkErAktivArbeidssoker() {
       }
       throw new Error(response.statusText);
     });
-    return perioder.filter((p: any) => !Boolean(p.avsluttet));
+    return perioder.filter((p: any) => !Boolean(p.avsluttet)).length > 0;
   } catch (err) {
     console.error(err);
     return false;

--- a/src/components/ux-signal/AiAUXSignals.tsx
+++ b/src/components/ux-signal/AiAUXSignals.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import UXSignalContent from "@components/ux-signal/UXSignalContent.tsx";
+import { aiaBackendUrl } from "@components/oversikt/urls.ts";
+import { getEnvironmentClientSide } from "@utils/client/environment.ts";
+
+async function fetchToggles() {
+  try {
+    return await fetch(`${aiaBackendUrl}/unleash?feature=aia.uxsignals`).then(response => {
+      if (response.ok) {
+        return response.json();
+      }
+      throw new Error(response.statusText);
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+async function sjekkErAktivArbeidssoker() {
+  try {
+    const perioder = await fetch(`${aiaBackendUrl}/arbeidssokerregisteret/v1/arbeidssoekerperioder`).then(response => {
+      if (response.ok) {
+        return response.json();
+      }
+      throw new Error(response.statusText);
+    });
+    return perioder.filter((p: any) => !Boolean(p.avsluttet));
+  } catch (err) {
+    console.error(err);
+    return false;
+  }
+}
+
+const AiAUXSignals = () => {
+  const [toggledOn, setToggledOn] = useState<boolean>(false);
+
+  useEffect(() => {
+    async function checkToggledOn() {
+      const toggles = await fetchToggles();
+      if (toggles["aia.uxsignals"]) {
+        setToggledOn(await sjekkErAktivArbeidssoker());
+      }
+    }
+
+    checkToggledOn();
+  }, []);
+
+  if (!toggledOn) {
+    return null;
+  }
+
+  return <UXSignalContent panelId={"panel-zelu70575h"} mode={getEnvironmentClientSide() !== 'prod' ? 'demo' : ''} />
+}
+
+export default AiAUXSignals;

--- a/src/components/ux-signal/UXSignal.astro
+++ b/src/components/ux-signal/UXSignal.astro
@@ -1,8 +1,8 @@
 ---
-import UXSignalContent from "./UXSignalContent";
 import styles from  "./UXSignal.module.css";
+import AiAUXSignals from "./AiAUXSignals";
 ---
 
 <div class={styles.wrapper} >
-  <UXSignalContent client:only="react" />
+  <AiAUXSignals client:only="react"/>
 </div>

--- a/src/components/ux-signal/UXSignalContent.jsx
+++ b/src/components/ux-signal/UXSignalContent.jsx
@@ -1,9 +1,0 @@
-import useUXSignalScript from "./useUXSignalScript"
-
-const UXSignalContent = () => {
-  useUXSignalScript(true);
-
-  return <div data-uxsignals-embed="panel-7jxjwg43ny" style={{ maxWidth: "620px" }} />;
-};
-
-export default UXSignalContent;

--- a/src/components/ux-signal/UXSignalContent.tsx
+++ b/src/components/ux-signal/UXSignalContent.tsx
@@ -1,0 +1,14 @@
+import useUXSignalScript from "./useUXSignalScript.tsx";
+
+interface Props {
+  panelId: string;
+  mode?: 'demo' | '';
+}
+
+const UXSignalContent = (props: Props) => {
+  useUXSignalScript(true);
+
+  return <div data-uxsignals-embed={props.panelId} style={{ maxWidth: "620px" }} data-uxsignals-mode={props.mode ?? ''}/>;
+};
+
+export default UXSignalContent;

--- a/src/components/ux-signal/useUXSignalScript.tsx
+++ b/src/components/ux-signal/useUXSignalScript.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-const useUXSignalScript = (ready) => {
+const useUXSignalScript = (ready: boolean) => {
   useEffect(() => {
     const script = document.createElement("script");
     script.async = true;
@@ -13,7 +13,6 @@ const useUXSignalScript = (ready) => {
       try {
         document.body.removeChild(script);
       } catch {
-        return;
       }
     };
   }, [ready]);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,7 @@ import Feilmelding from "@components/feilmelding/Feilmelding";
 import { getLanguage } from "@language/language";
 import Observability from "@components/obersvability/Observability";
 import Aktuelt from "@components/aktuelt/Aktuelt";
+import UXSignal from "../components/ux-signal/UXSignal.astro";
 
 const language = getLanguage(Astro.url);
 ---
@@ -29,6 +30,7 @@ const language = getLanguage(Astro.url);
       <Dokumentarkiv />
       <Aktuelt language={language} client:only="react" />
     </Container>
+    <UXSignal />
     <InnloggedeTjenester />
   </Content>
   <Observability client:only="react" />


### PR DESCRIPTION
Skriver litt om uxsignals-komponentene som var der, bruker typescript, og tar imot panel-id som prop. Inkluderer en egen AiAUXSignals-komponent som sjekker feature-toggle og gjør et api-kall for bare å inkludere for brukere som er aktive arbeidssøkere.