### PR TITLE
Fjerner ux-signals

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,6 @@ import Feilmelding from "@components/feilmelding/Feilmelding";
 import { getLanguage } from "@language/language";
 import Observability from "@components/obersvability/Observability";
 import Aktuelt from "@components/aktuelt/Aktuelt";
-import UXSignal from "../components/ux-signal/UXSignal.astro";
 
 const language = getLanguage(Astro.url);
 ---
@@ -30,7 +29,6 @@ const language = getLanguage(Astro.url);
       <Dokumentarkiv />
       <Aktuelt language={language} client:only="react" />
     </Container>
-    <UXSignal />
     <InnloggedeTjenester />
   </Content>
   <Observability client:only="react" />


### PR DESCRIPTION
Fjerner ux-signals fra å bli sendt til browseren. Team Paw kommer til å bruke dette senere så logikken for det beholdes i koden.