### PR TITLE
Legg til copilot-instructions.md og sync nav-pilot

### DIFF
--- a/.github/.nav-pilot-state.json
+++ b/.github/.nav-pilot-state.json
@@ -1,8 +1,8 @@
 {
   "collection": "frontend",
-  "version": "2026.04.20-194821-8b2cb9f",
+  "version": "2026.04.27-201649-b3cecb8",
   "scope": "repo",
-  "source_sha": "8b2cb9f",
+  "source_sha": "b3cecb8",
   "installed_at": "2026-04-24T09:58:45Z",
   "files": [
     {
@@ -23,7 +23,7 @@
     },
     {
       "path": ".github/agents/forfatter.agent.md",
-      "hash": "f638bd5c234f329b"
+      "hash": "13a58d6edf244114"
     },
     {
       "path": ".github/agents/forfatter.metadata.json",
@@ -31,7 +31,7 @@
     },
     {
       "path": ".github/agents/nav-pilot.agent.md",
-      "hash": "3179adb5db9ae3af"
+      "hash": "75c6d1771bdce25c"
     },
     {
       "path": ".github/agents/nav-pilot.metadata.json",

--- a/.github/agents/forfatter.agent.md
+++ b/.github/agents/forfatter.agent.md
@@ -1,6 +1,6 @@
 ---
 name: forfatter
-description: "Norsk teknisk redaktør: klarspråk, AI-markører, anglismer, fagtermer, mikrotekst."
+description: "Norsk teknisk redaktør, tekstforfatter eller innholdsdesigner: klarspråk, AI-markører, anglisismer, fagtermer, mikrotekst."
 tools:
   - read
   - edit
@@ -13,16 +13,16 @@ tools:
 
 # Tekstredaktør
 
-Du er en norsk teknisk redaktør. Du redigerer tekst på norsk bokmål for utviklere, driftere og arkitekter i Nav.
+Du er fagperson på tekst, både teknisk og mer generell. Du redigerer tekst på norsk bokmål for utviklere, de som jobber med IT-drift og arkitekter i Nav.
 
 ## Denne agenten redigerer tekst — ikke kode
 
-Du er en språklig redaktør, ikke en utvikler. Hvis brukeren ber om noe som ikke handler om norsk tekst, språkvask eller presentasjon, avslå høflig og foreslå å bytte agent.
+Du er fagperson innen språk og tekstforfatting, ikke utvikler. Hvis brukeren ber om noe som ikke handler om norsk tekst, språkvask eller presentasjon, avslå høflig og foreslå å bytte agent.
 
 **Du gjør:**
 - Språkvask av norsk tekst i markdown, TSX, HTML, YAML og kode-kommentarer
 - Redigering av README-er, ADR-er, UI-tekst, commit-meldinger, issue-beskrivelser
-- Fjerne AI-markører og anglismer
+- Fjerne AI-markører og anglisismer
 - Forbedre struktur og lesbarhet
 
 **Du gjør ikke:**
@@ -33,7 +33,7 @@ Du er en språklig redaktør, ikke en utvikler. Hvis brukeren ber om noe som ikk
 
 Hvis brukeren ber om noe utenfor ditt område, svar omtrent slik:
 
-> Jeg er tekstredaktøren — dette ser ut som en utviklingsoppgave. Bytt til en annen agent (trykk Shift+Tab) eller bruk `@nav-pilot` for kode og arkitektur.
+> Jeg redigerer tekst — dette ser ut som en utviklingsoppgave. Bytt til en annen agent (trykk Shift+Tab) eller bruk `@nav-pilot` for kode og arkitektur.
 
 ## Klarspråk
 
@@ -54,11 +54,11 @@ Start med konklusjonen eller det leseren trenger å vite. Bakgrunn og kontekst k
 
 ### Skriv for leseren
 
-Tenk: hva trenger leseren å gjøre etter å ha lest dette? Kutt alt som ikke hjelper dem.
+Tenk: Hva trenger leseren å gjøre etter å ha lest dette? Kutt alt som ikke hjelper dem.
 
 ### Unngå substantivsyke
 
-Bruk verb, ikke substantiv av verb. Nominalisering gjør teksten tung.
+Bruk verb, ikke substantiv laget av verb. De gjør teksten tung. Eksempel: ing + av: vurdering av sikkerheten - vurdere sikkerheten.
 
 ```
 ❌ Vi foretar en gjennomgang av implementasjonen.
@@ -83,8 +83,8 @@ Bruk verb, ikke substantiv av verb. Nominalisering gjør teksten tung.
 ### Struktur
 
 - Korte avsnitt (2–4 setninger)
-- Gode mellomtitler som sier hva seksjonen handler om
-- Kulepunkter for lister, ikke lange kommaseparerte oppramsinger
+- Gode mellomtitler som sier hva tekstdelen handler om
+- Kulepunkter for lister, ikke lange oppramsinger som er atskilt med komma
 - Bare første ord og egennavn med stor bokstav i overskrifter (ikke engelsk stil)
 
 ## AI-markører
@@ -119,7 +119,7 @@ Kutt disse — start med poenget:
 
 ### Strukturelle mønstre
 
-- Fjern oppsummeringssetninger på slutten av seksjoner som bare gjentar det du allerede har skrevet
+- Fjern oppsummeringssetninger på slutten av tekstdeler som bare gjentar det du allerede har skrevet
 - Ikke tving balanse mellom alternativer når ett er bedre ("begge har sine fordeler")
 - Varier grammatisk struktur i kulepunkter — identisk form er et AI-tegn
 - Ikke definer ting leseren allerede vet
@@ -129,7 +129,7 @@ Kutt disse — start med poenget:
 
 ### Overgangsord
 
-- "Videre", "Dessuten", "I tillegg" som paragrafåpner → bruk sjelden
+- "Videre", "Dessuten", "I tillegg" som åpning i et avsnitt → bruk sjelden
 - "I lys av dette", "Når det gjelder" → gå rett på sak
 - "Furthermore", "Moreover", "Additionally" → aldri i norsk tekst
 
@@ -149,7 +149,7 @@ Noen engelske ord brukes mye oftere i KI-generert tekst enn i vanlig norsk. Vær
 
 ### Tegnsetting og formatering
 
-- Em dash (—) er OK, men ikke i annethvert kulepunkt. Varier med kolon, parentes, eller omskriving.
+- Em dash (tankestrek) (—) er OK, men ikke i annethvert kulepunkt. Varier med kolon, parentes, eller omskriving.
 - Ikke bruk semikolon unaturlig ofte
 - Dropp utropstegn i teknisk tekst
 - Kolon (:) i hver eneste overskrift og kulepunkt er et AI-tegn. Varier.
@@ -196,13 +196,13 @@ Bruk bindestrek:
 ❌ Postgres operatoren, Kafka topicet, GitHub repoet (særskrivingsfeil)
 ```
 
-## Anglismer
+## Anglisismer
 
-Skille mellom etablerte fagtermer (behold engelsk) og unødvendige anglismer (bruk norsk).
+Skill mellom etablerte fagtermer (behold engelsk) og unødvendige anglisismer (bruk norsk).
 
-### Unødvendige anglismer — bruk norsk
+### Unødvendige anglisismer — bruk norsk
 
-| Anglisme | Norsk alternativ |
+| Anglisisme | Norsk alternativ |
 |----------|-----------------|
 | "tok et øyeblikk" (took a moment) | "ventet litt", "nølte" |
 | "i person" (in person) | "personlig", "ansikt til ansikt" |
@@ -315,7 +315,7 @@ Følg Designsystemets tverretatlige retningslinjer for tekst i digitale tjeneste
    i namespacet.
 ```
 
-### Anglisme → naturlig norsk
+### Anglisisme → naturlig norsk
 
 ```
 ❌ Vi må adressere dette problemet og ta eierskap til prosessen
@@ -385,7 +385,7 @@ Følg Designsystemets tverretatlige retningslinjer for tekst i digitale tjeneste
 ## Arbeidsflyt
 
 1. Les hele filen først
-2. Identifiser: AI-markører, substantivsyke, feiloversatte fagtermer, anglismer, konservativt formvalg, dårlig struktur
+2. Identifiser: AI-markører, substantivsyke, feiloversatte fagtermer, anglisismer, konservativt formvalg, dårlig struktur
 3. Tilpass redigeringa til teksttypen (ADR, README, UI-tekst, blogg)
 4. Foreslå endringer med kort forklaring, eller gjør dem direkte hvis brukeren har bedt om det
 5. Ikke endre faglig innhold — bare språk, form og struktur
@@ -407,7 +407,7 @@ Eksempel på delegering:
 - src/components/VedtakAlert.tsx
 - docs/README.md
 
-Scope: Kun brukervendt norsk tekst. Behold engelske fagtermer.
+Scope: Kun brukerrettet norsk tekst. Behold engelske fagtermer.
 ```
 
 Svar med:
@@ -431,7 +431,7 @@ Svar med:
 
 - Endringer som kan påvirke faglig innhold
 - Omstrukturering av hele dokumenter
-- Fjerning av seksjoner (ikke bare setninger)
+- Fjerning av hele avsnitt/tekstdeler (ikke bare setninger)
 
 ### 🚫 Aldri
 

--- a/.github/agents/nav-pilot.agent.md
+++ b/.github/agents/nav-pilot.agent.md
@@ -168,6 +168,12 @@ Ask targeted questions to uncover blind spots. Nav developers commonly forget:
 
 Not all blind spots apply to every project. Skip irrelevant ones (e.g., decommissioning for greenfield), but always report which were covered vs skipped in the checkpoint.
 
+**Repo-local Copilot config** — At the start of Phase 1, check if the current repo has these files. If any are missing, mention it in the checkpoint and suggest `nav-pilot init` to scaffold them:
+
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `.github/copilot-review-instructions.md`
+
 Use `$nav-deep-interview` for a more thorough interview process if the user requests it.
 
 ### Fase 2: Plan — «Slik bygger vi det»

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,122 @@
+# Copilot Instructions — tms-min-side
+
+Min side er en **Astro SSR-applikasjon** som er en container for mikrofrontends. Den henter personalisert innhold fra backend-tjenester via OBO-token exchange og setter det sammen til én side for innloggede brukere på nav.no.
+
+## Kommandoer
+
+```bash
+# Lokal utvikling — begge må kjøre samtidig
+pnpm run dev        # Astro dev-server på http://localhost:4321/minside
+pnpm run mock       # Hono mock-server (erstatter backend-APIer lokalt)
+
+# Bygg og forhåndsvis
+pnpm run build
+pnpm run preview    # Kjør prod-build lokalt
+
+# Formatering (kjøres automatisk av husky pre-commit)
+pnpm run prettier
+```
+
+Det finnes ingen `test`-script i `package.json`.
+
+## Arkitektur
+
+### Mikrofrontend-container
+
+`tms-min-side` henter HTML fra mikrofrontends server-side (SSR) og setter den inn direkte i siden. Hvert mikrofrontend-kall bruker OBO-token (TokenX) for autentisering mot den aktuelle tjenesten.
+
+```
+Browser → Astro SSR → getOboToken(token, audience)
+                    → fetchHtml(oboToken, url)
+                    → <Fragment set:html={html} />
+```
+
+Mikrofrontend-metadata (url, appname, namespace, fallback) kommer fra `tms-mikrofrontend-selector`.
+
+### Auth-flyt
+
+- **ID-porten + Wonderwall** håndterer innlogging (sidecar i Nais)
+- Middleware (`src/middleware/index.ts`) validerer token via `@navikt/oasis`
+- Validert token lagres i `Astro.locals.token`
+- `isLocal` (`NODE_ENV === "development"`) hopper over validering og returnerer fake token
+
+### Komponentstruktur
+
+| Type | Når | Eksempel |
+|------|-----|---------|
+| `.astro` | Server-rendered, data-fetching i frontmatter | `DinOversikt.astro`, `Microfrontend.astro` |
+| `.tsx` | Client-interaktive React-komponenter | `Produktkort.tsx`, `ClientError.tsx` |
+| `client:only="react"` | Komponenter som ikke skal SSR | `Feilmelding`, `Observability`, `Legacy` |
+| `server:defer` | Utsatt SSR med fallback-slot | `<DinOversikt server:defer>` |
+
+### Sidestruktur og i18n
+
+Sider ligger under `src/pages/[lang]/` — `lang` er `nb` (default), `nn` eller `en`. `getLanguage(url)` henter språk fra URL-path. All brukervendt tekst ligger i `src/language/` eller per-komponent `language/text.ts`.
+
+### Nanostores (global state)
+
+`src/store/store.ts` eksporterer `isErrorAtom`. Bruk `setIsError()` ved API-feil — `ClientError`-komponenten reagerer på denne.
+
+## Viktige konvensjoner
+
+### Path-aliaser (tsconfig)
+
+```typescript
+@components/*  → src/components/*
+@hooks/*       → src/hooks/*
+@language/*    → src/language/*
+@utils/*       → src/utils/*
+```
+
+### Server vs. klient utilities
+
+- `@utils/server/` — kun SSR: `token.ts`, `fetch.ts`, `logger.ts`, `environment.ts`
+- `@utils/client/` — kun browser: `api.ts`, `environment.ts`, `amplitude.ts`
+
+`isLocal` fra `@utils/server/environment.ts` brukes til å detektere lokal kjøring. Bruk `!import.meta.env.SSR`-guard i klient-utilities.
+
+### OBO-token-mønster
+
+```typescript
+const audience = getAudience("appname", "namespace"); // default namespace: "min-side"
+const oboToken = await getOboToken(Astro.locals.token, audience);
+const data = await fetchData(oboToken, url);
+```
+
+### Feilhåndtering i `.astro`-komponenter
+
+```astro
+let isError = false;
+try {
+  data = await fetchData(oboToken, url);
+} catch (error) {
+  logger.error(`...`);
+  isError = true;
+}
+---
+{isError && <ClientError client:only="react" />}
+```
+
+### CSS
+
+Bruk CSS Modules (`.module.css`) for komponent-spesifikke stiler. Globale stiler i `src/layouts/`.
+
+### Mock-server
+
+`mock/server.ts` er en Hono-server som etterligner alle backend-APIer lokalt. Legg til nye endepunkter her med tilhørende JSON-data i `mock/data/`. Serveren kjører på port 3000, Astro proxier mot den.
+
+## Nais-konfigurasjon
+
+- **Namespace**: `min-side`, **Team**: `min-side`
+- **Auth**: `idporten.enabled: true` + `tokenx.enabled: true`
+- **Base path**: `/minside`
+- **Health**: `/minside/api/internal/isAlive` og `/minside/api/internal/isReady`
+- **Metrics**: `/minside/api/internal/metrics` (Prometheus)
+- **CDN**: Static assets deployes til `https://cdn.nav.no/min-side/tms-min-side`
+- Legg til nye mikrofrontend-tjenester i `accessPolicy.outbound.rules` i `nais/*/nais.yaml`
+
+## Deploy
+
+- **main** → automatisk deploy til prod-gcp (`deploy-main.yaml`)
+- **manuell** → dev-gcp via `workflow_dispatch` (`deploy-dev.yaml`)
+- Build krever `ASTRO_KEY`-secret og `NAIS_WORKLOAD_IDENTITY_PROVIDER`


### PR DESCRIPTION
## Beskrivelse

Legger til `.github/copilot-instructions.md` som hjelper fremtidige Copilot-sesjoner å jobbe effektivt i dette repoet, samt oppdaterer nav-pilot agent-konfigurasjon.

## Endringer

- `.github/copilot-instructions.md`: Ny fil med build/dev-kommandoer, arkitekturoversikt og kodekonvensjoner for tms-min-side
- `.github/agents/nav-pilot.agent.md`: Oppdatert med utvidet funksjonalitet (språkvask-trinn, ubiquitous-language skill)
- `.github/agents/forfatter.agent.md`: Oppdatert agentinstrukser
- `.github/.nav-pilot-state.json`: Synkronisert tilstand

## Issue


## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)