### PR TITLE
chore: bytt ut husky med lefthook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-pnpm run format

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,25 @@
-pre-commit:
-  commands:
-    format:
-      run: pnpm run format
+{
+  "pre-commit": {
+    "commands": {
+      "check": {
+        "glob": "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,astro}",
+        "run": "pnpm exec biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}",
+        "stage_fixed": true
+      }
+    }
+  },
+  "pre-push": {
+    "commands": {
+      "typecheck": {
+        "run": "pnpm run typecheck"
+      }
+    }
+  },
+  "commit-msg": {
+    "commands": {
+      "no-empty-commit": {
+        "run": "git diff --cached --quiet || exit 0; echo \"Nothing staged to commit. Empty commits are blocked to keep history clean.\"; exit 1"
+      }
+    }
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-commit:
+  commands:
+    format:
+      run: pnpm run format

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "mock": "tsx mock/server.ts",
     "preview": "node ./dist/server/entry.mjs",
     "astro": "astro",
-    "format": "biome format --write --no-errors-on-unmatched src/"
+    "format": "biome format --write",
+    "typecheck": "astro check"
   },
   "dependencies": {
     "@astrojs/node": "10.0.5",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "mock": "tsx mock/server.ts",
     "preview": "node ./dist/server/entry.mjs",
     "astro": "astro",
-    "format": "biome format --write --no-errors-on-unmatched src/",
-    "prepare": "husky"
+    "format": "biome format --write --no-errors-on-unmatched src/"
   },
   "dependencies": {
     "@astrojs/node": "10.0.5",
@@ -25,7 +24,6 @@
     "@opentelemetry/sdk-node": "0.215.0",
     "astro": "6.1.8",
     "dayjs": "1.11.20",
-    "husky": "9.1.7",
     "nanostores": "1.3.0",
     "pino": "9.9.5",
     "prom-client": "15.1.3",
@@ -35,6 +33,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
+    "@evilmartians/lefthook": "1.11.13",
     "@hono/node-server": "2.0.0",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
-    "@evilmartians/lefthook": "1.11.13",
+    "lefthook": "2.1.6",
     "@hono/node-server": "2.0.0",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.13
         version: 2.4.13
-      '@evilmartians/lefthook':
-        specifier: 1.11.13
-        version: 1.11.13
       '@hono/node-server':
         specifier: 2.0.0
         version: 2.0.0(hono@4.12.15)
@@ -93,6 +90,9 @@ importers:
       hono:
         specifier: 4.12.15
         version: 4.12.15
+      lefthook:
+        specifier: 2.1.6
+        version: 2.1.6
       prop-types:
         specifier: 15.8.1
         version: 15.8.1
@@ -451,12 +451,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@evilmartians/lefthook@1.11.13':
-    resolution: {integrity: sha512-CcR9u7lb3uCKD+295S2GfhROI6q9npTsJ/E07XupZZFO8sdYHm3Uo3x8t+lzKmI/7rCFA2t0MWRggjNrxpjXFg==}
-    cpu: [x64, arm64, ia32]
-    os: [darwin, linux, win32]
-    hasBin: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1689,6 +1683,60 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
+    hasBin: true
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -2856,8 +2904,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
-
-  '@evilmartians/lefthook@1.11.13': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4142,6 +4188,49 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   lodash.camelcase@4.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       dayjs:
         specifier: 1.11.20
         version: 1.11.20
-      husky:
-        specifier: 9.1.7
-        version: 9.1.7
       nanostores:
         specifier: 1.3.0
         version: 1.3.0
@@ -69,6 +66,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.13
         version: 2.4.13
+      '@evilmartians/lefthook':
+        specifier: 1.11.13
+        version: 1.11.13
       '@hono/node-server':
         specifier: 2.0.0
         version: 2.0.0(hono@4.12.15)
@@ -451,6 +451,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@evilmartians/lefthook@1.11.13':
+    resolution: {integrity: sha512-CcR9u7lb3uCKD+295S2GfhROI6q9npTsJ/E07XupZZFO8sdYHm3Uo3x8t+lzKmI/7rCFA2t0MWRggjNrxpjXFg==}
+    cpu: [x64, arm64, ia32]
+    os: [darwin, linux, win32]
+    hasBin: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1611,11 +1617,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
@@ -2856,6 +2857,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@evilmartians/lefthook@1.11.13': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -4092,8 +4095,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  husky@9.1.7: {}
 
   import-in-the-middle@3.0.1:
     dependencies:


### PR DESCRIPTION
Bytter ut `husky` med `lefthook` for håndtering av Git-hooks.

## Endringer
- Fjerner `husky` fra `dependencies` og `prepare`-script fra `package.json`
- Sletter `.husky/pre-commit`
- Legger til `@evilmartians/lefthook` i `devDependencies`
- Oppretter `lefthook.yml` med tilsvarende `pre-commit`-hook (`pnpm run format`)

Closes #568