### PR TITLE
Refaktorering: erstatt Language med Locale

### DIFF
--- a/src/features/aktuelt/Aktuelt.astro
+++ b/src/features/aktuelt/Aktuelt.astro
@@ -4,7 +4,7 @@ import { BodyShort, Skeleton } from "@navikt/ds-react";
 import ClientError from "@src/shared/client-error/ClientError";
 import Microfrontend from "@src/shared/microfrontends/Microfrontend.astro";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Language } from "@src/shared/utils/server/language.ts";
+import type { Locale } from "@src/shared/utils/server/locale.ts";
 import logger from "@src/shared/utils/server/logger.ts";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import style from "./Aktuelt.module.css";
@@ -13,7 +13,7 @@ import type { Aktuelt } from "./aktueltTypes";
 
 const audience = getAudience("tms-mikrofrontend-selector");
 const oboToken = await getOboToken(Astro.locals.token, audience);
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 
 let aktuelt: Aktuelt = { offerStepup: false, microfrontends: [] };
 let isError = false;
@@ -36,11 +36,11 @@ try {
       return (
         <div class={style.container}>
           <BodyShort as="h2" className={style.aktuelt} spacing>
-            {text.aktuelt[language]}
+            {text.aktuelt[locale]}
           </BodyShort>
           {aktuelt.microfrontends.map((mf) => {
             return (
-              <Microfrontend microfrontend={mf} language={language} server:defer>
+              <Microfrontend microfrontend={mf} locale={locale} server:defer>
                 <Skeleton variant="rounded" width={"100%"} height={100} slot="fallback"/>
               </Microfrontend>
             );

--- a/src/features/alert-island/utkast/Utkast.astro
+++ b/src/features/alert-island/utkast/Utkast.astro
@@ -3,7 +3,7 @@ import { UTKAST_API_URL, UTKAST_URL } from "astro:env/server";
 import ClientError from "@src/shared/client-error/ClientError";
 import { MultiStatusError } from "@src/shared/utils/server/error";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import UtkastIkon from "./assets/UtkastIkon.tsx";
@@ -29,23 +29,23 @@ try {
   isError = true;
 }
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 const antall = data ? data.antall : 0;
 const hasUtkast = antall > 0;
-const ingress = antall === 1 ? text.soknad[language] : text.soknader[language](antall);
+const ingress = antall === 1 ? text.soknad[locale] : text.soknader[locale](antall);
 ---
 
 {isError && <ClientError client:only="react" />}
 {
   hasUtkast && (
     <div class={style.wrapper} id="utkast">
-      <a href={`${UTKAST_URL}/${language}`} class={style.utkast}>
+      <a href={`${UTKAST_URL}/${locale}`} class={style.utkast}>
         <div class={style.ikonRektangel}>
           <UtkastIkon />
           <UtkastIkonHover />
         </div>
         <div class={style.container}>
-          <h3 class={style.heading}>{text.utkast[language]}</h3>
+          <h3 class={style.heading}>{text.utkast[locale]}</h3>
           <p class={style.tekst}>{ingress}</p>
         </div>
       </a>

--- a/src/features/alert-island/varsler/Varsler.astro
+++ b/src/features/alert-island/varsler/Varsler.astro
@@ -3,7 +3,7 @@ import { VARSEL_API_URL, VARSLER_URL } from "astro:env/server";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import IngenVarslerIkon from "./assets/IngenVarslerIkon";
@@ -30,9 +30,9 @@ const oppgaver = data.oppgaver || 0;
 const beskjeder = data.beskjeder + data.innbokser;
 const varsler = beskjeder + oppgaver;
 
-const language = Astro.currentLocale as Language;
-const oppgaveText = oppgaveSingular(oppgaver) ? text.oppgave[language] : text.oppgaver[language];
-const beskjedText = beskjedSingular(beskjeder) ? text.beskjed[language] : text.beskjeder[language];
+const locale = Astro.currentLocale as Locale;
+const oppgaveText = oppgaveSingular(oppgaver) ? text.oppgave[locale] : text.oppgaver[locale];
+const beskjedText = beskjedSingular(beskjeder) ? text.beskjed[locale] : text.beskjeder[locale];
 ---
 
 {isError && <ClientError client:only="react" />}
@@ -46,8 +46,8 @@ const beskjedText = beskjedSingular(beskjeder) ? text.beskjed[language] : text.b
             <VarselBjelleDotUtenFyll />
           </div>
           <div class={style.container}>
-            <h3 class={style.heading}>{text.varsler[language]}</h3>
-            <p class={style.tekst}>{buildText(beskjeder, oppgaver, beskjedText, oppgaveText, text.og[language])}</p>
+            <h3 class={style.heading}>{text.varsler[locale]}</h3>
+            <p class={style.tekst}>{buildText(beskjeder, oppgaver, beskjedText, oppgaveText, text.og[locale])}</p>
           </div>
         </a>
       )
@@ -56,8 +56,8 @@ const beskjedText = beskjedSingular(beskjeder) ? text.beskjed[language] : text.b
         <a href={VARSLER_URL} class={style.varsler}>
           <IngenVarslerIkon />
           <div class={style.container}>
-            <h3 class={style.heading}>{text.varsler[language]}</h3>
-            <p class={style.tekst}>{text.ingenVarsler[language]}</p>
+            <h3 class={style.heading}>{text.varsler[locale]}</h3>
+            <p class={style.tekst}>{text.ingenVarsler[locale]}</p>
           </div>
         </a>
         )

--- a/src/features/din-oversikt/DinOversikt.astro
+++ b/src/features/din-oversikt/DinOversikt.astro
@@ -6,7 +6,7 @@ import Microfrontend from "@src/shared/microfrontends/Microfrontend.astro";
 import MicrofrontendSkeleton from "@src/shared/microfrontends/MicrofrontendSkeleton.astro";
 import { MultiStatusError } from "@src/shared/utils/server/error";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import styles from "./DinOversikt.module.css";
@@ -20,7 +20,7 @@ import { getShowDinOversikt } from "./useOversikt.ts";
 
 const audience = getAudience("tms-mikrofrontend-selector");
 const oboToken = await getOboToken(Astro.locals.token, audience);
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 
 let isError = false;
 let personalizedContent: PersonalizedContent = {
@@ -42,7 +42,7 @@ try {
   isError = true;
 }
 
-const produktkortList = getProduktkortList(language, personalizedContent);
+const produktkortList = getProduktkortList(locale, personalizedContent);
 const showDinOversikt = getShowDinOversikt(personalizedContent, produktkortList);
 ---
 
@@ -51,18 +51,18 @@ const showDinOversikt = getShowDinOversikt(personalizedContent, produktkortList)
   showDinOversikt && (
     <div class={styles.oversiktContainer}>
       <BodyShort as="h2" spacing>
-        {produktText.oversiktTittel[language]}
+        {produktText.oversiktTittel[locale]}
       </BodyShort>
       {personalizedContent?.meldekort && (
         <div class={styles.meldekort}>
-          <Meldekort language={language} server:defer>
+          <Meldekort locale={locale} server:defer>
             <MeldekortSkeleton slot="fallback" />
           </Meldekort>
         </div>
       )}
       <div class={styles.masonry}>
         {personalizedContent?.microfrontends.map((mf) => (
-          <Microfrontend microfrontend={mf} language={language} server:defer>
+          <Microfrontend microfrontend={mf} locale={locale} server:defer>
             <MicrofrontendSkeleton slot="fallback" />
           </Microfrontend>
         ))}

--- a/src/features/din-oversikt/dinOversiktUtils.ts
+++ b/src/features/din-oversikt/dinOversiktUtils.ts
@@ -1,12 +1,12 @@
 import type { Microfrontend } from "@src/shared/microfrontends/microfrontendTypes.ts";
-import type { Language } from "@src/shared/utils/server/language.ts";
+import type { Locale } from "@src/shared/utils/server/locale.ts";
 import type { PersonalizedContent } from "./DinOversiktTypes";
 import { getProduktPropertiesMap } from "./produktkort/ProduktProperties.tsx";
 
-export const getProduktkortList = (language: Language, personalizedContent?: PersonalizedContent) => {
+export const getProduktkortList = (locale: Locale, personalizedContent?: PersonalizedContent) => {
   if (personalizedContent === undefined) return undefined;
 
-  const produktPropertiesMap = getProduktPropertiesMap(language);
+  const produktPropertiesMap = getProduktPropertiesMap(locale);
   const byKode = (a: string, b: string) => a.localeCompare(b);
   const toProduktProperties = (sakstema: string) => produktPropertiesMap[sakstema];
 

--- a/src/features/din-oversikt/meldekort/Meldekort.astro
+++ b/src/features/din-oversikt/meldekort/Meldekort.astro
@@ -6,10 +6,10 @@ import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 
 interface Props {
-  language: string;
+  locale: string;
 }
 
-const { language } = Astro.props;
+const { locale } = Astro.props;
 const audience = getAudience("meldekort-mikrofrontend", "meldekort");
 const oboToken = await getOboToken(Astro.locals.token, audience);
 
@@ -17,11 +17,11 @@ let isError = false;
 let html = "";
 
 try {
-  html = await fetchMicrofrontend(oboToken, `${MELDEKORT_URL}/${language}`);
+  html = await fetchMicrofrontend(oboToken, `${MELDEKORT_URL}/${locale}`);
 } catch (error) {
   logger.error(`Failed to fetch meldekort microfrontend. Error: ${error}`);
   isError = true;
-  html = await fetchMicrofrontend(oboToken, `${MELDEKORT_URL}/${language}/fallback`);
+  html = await fetchMicrofrontend(oboToken, `${MELDEKORT_URL}/${locale}/fallback`);
 }
 ---
 

--- a/src/features/din-oversikt/produktkort/ProduktProperties.tsx
+++ b/src/features/din-oversikt/produktkort/ProduktProperties.tsx
@@ -5,65 +5,65 @@ import IkonPensjon from "@src/features/din-oversikt/assets/IkonPensjon";
 import IkonSykefravær from "@src/features/din-oversikt/assets/IkonSykefravær";
 import IkonUføretrygd from "@src/features/din-oversikt/assets/IkonUføretrygd";
 import IkonØkonomiskSosialhjelp from "@src/features/din-oversikt/assets/IkonØkonomiskSosialhjelp";
-import type { Language } from "@src/shared/utils/server/language.ts";
+import type { Locale } from "@src/shared/utils/server/locale.ts";
 import type { ReactElement } from "react";
 import { produktText } from "./ProduktText";
 import { produktlinker as produktUrls } from "./ProduktUrls";
 
 type ProduktProperties = { produktnavn: string; url: string; tittel: string; ingress: string; ikon: ReactElement };
 
-export function getProduktPropertiesMap(language: Language): Record<string, ProduktProperties> {
+export function getProduktPropertiesMap(locale: Locale): Record<string, ProduktProperties> {
   const sykefraværConfig: ProduktProperties = {
     produktnavn: "sykefravær",
-    url: produktUrls.sykefravær[language],
-    tittel: produktText.sykefravær[language],
-    ingress: produktText.sykefraværIngress[language],
+    url: produktUrls.sykefravær[locale],
+    tittel: produktText.sykefravær[locale],
+    ingress: produktText.sykefraværIngress[locale],
     ikon: <IkonSykefravær />,
   };
 
   return {
     DAG: {
       produktnavn: "dagpenger",
-      url: produktUrls.dagpenger[language],
-      tittel: produktText.dagpenger[language],
-      ingress: produktText.generellIngress[language],
+      url: produktUrls.dagpenger[locale],
+      tittel: produktText.dagpenger[locale],
+      ingress: produktText.generellIngress[locale],
       ikon: <IkonDagpenger />,
     },
     FOR: {
       produktnavn: "foreldrepenger",
-      url: produktUrls.foreldrepenger[language],
-      tittel: produktText.foreldrepenger[language],
-      ingress: produktText.generellIngress[language],
+      url: produktUrls.foreldrepenger[locale],
+      tittel: produktText.foreldrepenger[locale],
+      ingress: produktText.generellIngress[locale],
       ikon: <IkonForeldrepenger />,
     },
     HJE: {
       produktnavn: "hjelpemidler",
-      url: produktUrls.hjelpemidler[language],
-      tittel: produktText.hjelpemidler[language],
-      ingress: produktText.generellIngress[language],
+      url: produktUrls.hjelpemidler[locale],
+      tittel: produktText.hjelpemidler[locale],
+      ingress: produktText.generellIngress[locale],
       ikon: <IkonHjelpemidler />,
     },
     KOM: {
       produktnavn: "sosialhjelp",
-      url: produktUrls.sosialhjelp[language],
-      tittel: produktText.sosialhjelp[language],
-      ingress: produktText.sosialhjelpIngress[language],
+      url: produktUrls.sosialhjelp[locale],
+      tittel: produktText.sosialhjelp[locale],
+      ingress: produktText.sosialhjelpIngress[locale],
       ikon: <IkonØkonomiskSosialhjelp />,
     },
     PEN: {
       produktnavn: "pensjon",
-      url: produktUrls.pensjon[language],
-      tittel: produktText.pensjon[language],
-      ingress: produktText.pensjonIngress[language],
+      url: produktUrls.pensjon[locale],
+      tittel: produktText.pensjon[locale],
+      ingress: produktText.pensjonIngress[locale],
       ikon: <IkonPensjon />,
     },
     SYK: sykefraværConfig,
     SYM: sykefraværConfig,
     UFO: {
       produktnavn: "uføretrygd",
-      url: produktUrls.uføretrygd[language],
-      tittel: produktText.uføretrygd[language],
-      ingress: produktText.uføretrygdIngress[language],
+      url: produktUrls.uføretrygd[locale],
+      tittel: produktText.uføretrygd[locale],
+      ingress: produktText.uføretrygdIngress[locale],
       ikon: <IkonUføretrygd />,
     },
   };

--- a/src/features/dokumenter/Dokumenter.astro
+++ b/src/features/dokumenter/Dokumenter.astro
@@ -5,7 +5,7 @@ import { BodyLong, BodyShort, Heading } from "@navikt/ds-react";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import styles from "./Dokumenter.module.css";
@@ -31,13 +31,13 @@ try {
 }
 
 const hasIngenDokumenter = data.length === 0;
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 {isError && <ClientError client:only="react" />}
 {() => {
     if (isSubstantial) {
-      return <MinIDDokumenter language={language}/>;
+      return <MinIDDokumenter locale={locale}/>;
     }
 
     if (hasIngenDokumenter) {
@@ -45,16 +45,16 @@ const language = Astro.currentLocale as Language;
         <div class={styles.container}>
           <div class={styles.heading}>
             <Heading level="2" size="xsmall">
-              {text.heading[language]}
+              {text.heading[locale]}
             </Heading>
           </div>
           <div class={styles.ingress}>
             <BodyLong className={styles.text}>
-              {text.ingenText[language]}
+              {text.ingenText[locale]}
             </BodyLong>
           </div>
-          <a class={styles.ingenLink} href={`${DOKUMENTARKIV_URL}/${language}`} id="ingenDokumenterAlle">
-            {text.tidligere[language]}
+          <a class={styles.ingenLink} href={`${DOKUMENTARKIV_URL}/${locale}`} id="ingenDokumenterAlle">
+            {text.tidligere[locale]}
           </a>
         </div>
       );
@@ -62,7 +62,7 @@ const language = Astro.currentLocale as Language;
       return (
         <div class={styles.container}>
           <Heading size="xsmall" level="2" spacing>
-            {text.heading[language]}
+            {text.heading[locale]}
           </Heading>
           <ul class={styles.dokumenter}>
             {data.map((dokument) => (
@@ -70,9 +70,9 @@ const language = Astro.currentLocale as Language;
             ))}
           </ul>
           <div class={styles.alle}>
-            <a class={styles.link} href={`${DOKUMENTARKIV_URL}/${language}`} id="alle">
+            <a class={styles.link} href={`${DOKUMENTARKIV_URL}/${locale}`} id="alle">
               <BodyShort size="medium">
-                {text.alle[language]}
+                {text.alle[locale]}
               </BodyShort>
             </a>
             <Chevron className={styles.chevron} aria-hidden={true} fontSize="20px" />

--- a/src/features/dokumenter/fallback/DokumenterFallback.astro
+++ b/src/features/dokumenter/fallback/DokumenterFallback.astro
@@ -1,14 +1,14 @@
 ---
 import { Heading, Skeleton } from "@navikt/ds-react";
 import { text } from "@src/features/dokumenter/dokumenterText";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 <div>
   <Heading size="xsmall" as="h2" spacing>
-    {text.heading[language]}
+    {text.heading[locale]}
   </Heading>
   <Skeleton variant="text" height="50px" width="100%" />
   <Skeleton variant="text" height="50px" width="100%" />

--- a/src/features/dokumenter/minid/MinIDDokumenter.astro
+++ b/src/features/dokumenter/minid/MinIDDokumenter.astro
@@ -1,23 +1,23 @@
 ---
 import { BodyLong, Heading } from "@navikt/ds-react";
 import { text } from "@src/features/dokumenter/dokumenterText";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import styles from "./MinIDDokumenter.module.css";
 
 interface Props {
-  language: Language;
+  locale: Locale;
 }
 
-const { language } = Astro.props;
+const { locale } = Astro.props;
 ---
 
 <div class={styles.container}>
   <div class={styles.heading}>
     <Heading level="2" size="xsmall">
-      {text.heading[language]}
+      {text.heading[locale]}
     </Heading>
   </div>
   <div class={styles.ingress}>
-    <BodyLong className={styles.text}>{text.minidIngress[language]}</BodyLong>
+    <BodyLong className={styles.text}>{text.minidIngress[locale]}</BodyLong>
   </div>
 </div>

--- a/src/features/innboks/Innboks.astro
+++ b/src/features/innboks/Innboks.astro
@@ -5,7 +5,7 @@ import { BodyLong, Heading } from "@navikt/ds-react";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import styles from "./Innboks.module.css";
@@ -27,20 +27,20 @@ try {
 
 const innbokser = data.innbokser;
 const type = innbokser > 0 ? "NyMelding" : "IngenNyMelding";
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 {isError && <ClientError client:only="react" />}
 <div class={styles.container}>
   <a class={`${styles.headerContainer} ${styles[`headerContainer${type}`]}`} href={INNBOKS_URL} id="innboks">
-    <Heading level="2" size="xsmall">{text.kommunikasjonsFlisLenketekstInnboks[language]}</Heading>
+    <Heading level="2" size="xsmall">{text.kommunikasjonsFlisLenketekstInnboks[locale]}</Heading>
     <div class={styles.tagChevron}>
-      <InnboksTag innbokser={innbokser} language={language} />
+      <InnboksTag innbokser={innbokser} locale={locale} />
       <Chevron className={styles.chevron} aria-hidden={true} fontSize="24px" />
     </div>
   </a>
   <div class={`${styles.bodyContainer} ${styles[`bodyContainer${type}`]}`}>
-    <BodyLong>{text.kommunikasjonsFlisIngressInnboks[language]}</BodyLong>
+    <BodyLong>{text.kommunikasjonsFlisIngressInnboks[locale]}</BodyLong>
   </div>
 </div>
 <PersonalContentLogger event={"innboks"} value={type === "NyMelding" ? true : false} client:only="react" />

--- a/src/features/innboks/InnboksTag.tsx
+++ b/src/features/innboks/InnboksTag.tsx
@@ -1,23 +1,23 @@
 import { Tag } from "@navikt/ds-react";
-import type { Language } from "@src/shared/utils/server/language.ts";
+import type { Locale } from "@src/shared/utils/server/locale.ts";
 import { text } from "./innboksText";
 
 interface Props {
   innbokser: number;
-  language: Language;
+  locale: Locale;
 }
 
-const InnboksTag = ({ innbokser, language }: Props) => {
+const InnboksTag = ({ innbokser, locale }: Props) => {
   if (innbokser > 0) {
     return (
       <Tag variant="alt3-filled" size="small">
-        {innbokser === 1 ? text.innboksNyMeldingEntall[language] : text.innboksNyMeldingFlertall[language](innbokser)}
+        {innbokser === 1 ? text.innboksNyMeldingEntall[locale] : text.innboksNyMeldingFlertall[locale](innbokser)}
       </Tag>
     );
   } else {
     return (
       <Tag variant="moderate" data-color="neutral" size="small">
-        {text.innboksIngenNyMeldinger[language]}
+        {text.innboksIngenNyMeldinger[locale]}
       </Tag>
     );
   }

--- a/src/features/innboks/fallback/InnboksFallback.astro
+++ b/src/features/innboks/fallback/InnboksFallback.astro
@@ -3,21 +3,21 @@ import { INNBOKS_URL } from "astro:env/server";
 import { BodyLong, BodyShort, Skeleton } from "@navikt/ds-react";
 import styles from "@src/features/innboks/Innboks.module.css";
 import { text } from "@src/features/innboks/innboksText";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 <div class={styles.container}>
   <div class={styles.content}>
     <a class={`${styles.headerContainer} ${styles.headerContainerIngenNyMelding}`} href={INNBOKS_URL}>
-      <BodyShort as="h2">{text.kommunikasjonsFlisLenketekstInnboks[language]}</BodyShort>
+      <BodyShort as="h2">{text.kommunikasjonsFlisLenketekstInnboks[locale]}</BodyShort>
       <div class={styles.tagChevron}>
         <Skeleton width={120} height={24} />
       </div>
     </a>
     <div class={`${styles.bodyContainer} ${styles.bodyContainerIngenNyMelding}`}>
-      <BodyLong>{text.kommunikasjonsFlisIngressInnboks[language]}</BodyLong>
+      <BodyLong>{text.kommunikasjonsFlisIngressInnboks[locale]}</BodyLong>
     </div>
   </div>
 </div>

--- a/src/features/innloggede-tjenester/InnloggedeTjenester.astro
+++ b/src/features/innloggede-tjenester/InnloggedeTjenester.astro
@@ -1,32 +1,32 @@
 ---
 import { BodyShort, Heading } from "@navikt/ds-react";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import styles from "./InnloggedeTjenester.module.css";
 import { text } from "./innloggedeTjenesterText";
 import { annetLenker, hjelpemidlerLenker, jobbLenker, personopplysningLenker } from "./innloggedeTjenesterUrls";
 import InnloggedeTjensterSection from "./section/InnloggedeTjenesterSection.astro";
 
-const language = Astro.currentLocale as Language;
-const isEnglish = language === "en";
+const locale = Astro.currentLocale as Locale;
+const isEnglish = locale === "en";
 ---
 
 <div class={styles.container}>
-  <Heading level="2" size="small" className={styles.tittel}>{text.innloggedeTjenester[language]}</Heading>
+  <Heading level="2" size="small" className={styles.tittel}>{text.innloggedeTjenester[locale]}</Heading>
   {
     isEnglish ? (
       <BodyShort size="medium" className={styles.disclaimer}>
-        {text.disclaimer[language]}
+        {text.disclaimer[locale]}
       </BodyShort>
     ) : null
   }
   <nav class={styles.sectionContainer}>
     <div class={styles.column}>
-      <InnloggedeTjensterSection tittel={text.jobbOgOppfolging[language]} lenker={jobbLenker} />
-      <InnloggedeTjensterSection tittel={text.dinOversikt[language]} lenker={hjelpemidlerLenker} />
+      <InnloggedeTjensterSection tittel={text.jobbOgOppfolging[locale]} lenker={jobbLenker} />
+      <InnloggedeTjensterSection tittel={text.dinOversikt[locale]} lenker={hjelpemidlerLenker} />
     </div>
     <div class={styles.column}>
-      <InnloggedeTjensterSection tittel={text.personopplysning[language]} lenker={personopplysningLenker} />
-      <InnloggedeTjensterSection tittel={text.annet[language]} lenker={annetLenker} />
+      <InnloggedeTjensterSection tittel={text.personopplysning[locale]} lenker={personopplysningLenker} />
+      <InnloggedeTjensterSection tittel={text.annet[locale]} lenker={annetLenker} />
     </div>
   </nav>
 </div>

--- a/src/features/innloggede-tjenester/link/LinkWithAmplitude.tsx
+++ b/src/features/innloggede-tjenester/link/LinkWithAmplitude.tsx
@@ -1,20 +1,20 @@
 import type { Lenke } from "@src/features/innloggede-tjenester/innloggedeTjenesterUrls";
 import style from "@src/features/innloggede-tjenester/section/InnloggedeTjensterSection.module.css";
 import { logEvent } from "@src/shared/utils/client/umami.ts";
-import type { Language } from "@src/shared/utils/server/language.ts";
+import type { Locale } from "@src/shared/utils/server/locale.ts";
 
 interface Props {
   link: Lenke;
-  language: Language;
+  locale: Locale;
 }
 
-const LinkWithAmplitude = ({ link, language }: Props) => (
+const LinkWithAmplitude = ({ link, locale }: Props) => (
   <a
     className={style.color}
-    href={link.url[language]}
+    href={link.url[locale]}
     onClick={() => logEvent("innloggede-tjenester-lenke", "innloggede-tjenester", link.nb)}
   >
-    {link[language]}
+    {link[locale]}
   </a>
 );
 

--- a/src/features/innloggede-tjenester/section/InnloggedeTjenesterSection.astro
+++ b/src/features/innloggede-tjenester/section/InnloggedeTjenesterSection.astro
@@ -3,7 +3,7 @@ import { ChevronRightIcon as Chevron } from "@navikt/aksel-icons";
 import { BodyShort, Detail } from "@navikt/ds-react";
 import type { Lenke } from "@src/features/innloggede-tjenester/innloggedeTjenesterUrls";
 import LinkWithAmplitude from "@src/features/innloggede-tjenester/link/LinkWithAmplitude";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import style from "./InnloggedeTjensterSection.module.css";
 
 interface Props {
@@ -11,7 +11,7 @@ interface Props {
   tittel: string;
 }
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 const { lenker, tittel } = Astro.props;
 ---
 
@@ -23,7 +23,7 @@ const { lenker, tittel } = Astro.props;
         <li class={style.link}>
           <Chevron className={style.chevron} fontSize="24px" aria-hidden={true} />
           <BodyShort>
-            <LinkWithAmplitude link={link} language={language} client:only="react" />
+            <LinkWithAmplitude link={link} locale={locale} client:only="react" />
           </BodyShort>
         </li>
       ))

--- a/src/features/personalia/Personalia.astro
+++ b/src/features/personalia/Personalia.astro
@@ -1,14 +1,14 @@
 ---
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import Navn from "./navn/Navn.astro";
 import style from "./Personalia.module.css";
 import { text } from "./personaliaText";
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 <div class={style.container}>
   <h2 class={style.tekst}>
-    <span>{text.hilsen[language]} <Navn server:defer /></span>
+    <span>{text.hilsen[locale]} <Navn server:defer /></span>
   </h2>
 </div>

--- a/src/features/substantial-info/SubstantialInfo.astro
+++ b/src/features/substantial-info/SubstantialInfo.astro
@@ -1,9 +1,9 @@
 ---
 import { Alert, BodyShort, Heading, Link } from "@navikt/ds-react";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import { text } from "./substantialInfoText";
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 const isSubstantial: boolean = Astro.locals.isSubstantial;
 ---
 
@@ -11,10 +11,10 @@ const isSubstantial: boolean = Astro.locals.isSubstantial;
   isSubstantial && (
     <Alert variant="info">
       <Heading level="2" size="xsmall">
-        {text.heading[language]}
+        {text.heading[locale]}
       </Heading>
-      <BodyShort>{text.info[language]}</BodyShort>
-      <Link href="/minside/oauth2/login?level=idporten-loa-high">{text.link[language]}</Link>
+      <BodyShort>{text.info[locale]}</BodyShort>
+      <Link href="/minside/oauth2/login?level=idporten-loa-high">{text.link[locale]}</Link>
     </Alert>
   )
 }

--- a/src/features/utbetaling/Utbetaling.astro
+++ b/src/features/utbetaling/Utbetaling.astro
@@ -3,7 +3,7 @@ import { UTBETALINGSOVERSIKT_API_URL } from "astro:env/server";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import EnkelUtbetaling from "./enkel/EnkelUtbetaling.astro";
@@ -27,7 +27,7 @@ try {
   isError = true;
 }
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 {isError && <ClientError client:only="react" />}
@@ -35,22 +35,22 @@ const language = Astro.currentLocale as Language;
   {
     () => {
       if (isIngen(utbetaling)) {
-        return <IngenUtbetaling language={language} />;
+        return <IngenUtbetaling locale={locale} />;
       }
 
       if (isKommende(utbetaling)) {
-        return <EnkelUtbetaling utbetaling={utbetaling.kommende!} language={language} utbetalingType="kommende" />;
+        return <EnkelUtbetaling utbetaling={utbetaling.kommende!} locale={locale} utbetalingType="kommende" />;
       }
 
       if (isTidligere(utbetaling)) {
-        return <EnkelUtbetaling utbetaling={utbetaling.sisteUtbetaling!} language={language} utbetalingType="tidligere" />;
+        return <EnkelUtbetaling utbetaling={utbetaling.sisteUtbetaling!} locale={locale} utbetalingType="tidligere" />;
       }
 
       if (isList(utbetaling)) {
-        return <UtbetalingList kommende={utbetaling.kommende!} language={language} tidligere={utbetaling.sisteUtbetaling!} />;
+        return <UtbetalingList kommende={utbetaling.kommende!} locale={locale} tidligere={utbetaling.sisteUtbetaling!} />;
       }
     }
   }
-  <SeAlle language={language} isKommende={isKommende(utbetaling)} />
+  <SeAlle locale={locale} isKommende={isKommende(utbetaling)} />
   <PersonalContentLogger event="utbetaling" value={!!utbetaling.kommende || !!utbetaling.sisteUtbetaling} client:only="react" />
 </div>

--- a/src/features/utbetaling/enkel/EnkelUtbetaling.astro
+++ b/src/features/utbetaling/enkel/EnkelUtbetaling.astro
@@ -5,16 +5,16 @@ import { BodyShort, Heading } from "@navikt/ds-react";
 import { text } from "@src/features/utbetaling/utbetalingText";
 import type { UtbetalingData } from "@src/features/utbetaling/utbetalingTypes";
 import { formatToReadableDate } from "@src/features/utbetaling/utbetalingUtils";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import styles from "./EnkelUtbetaling.module.css";
 
 interface Props {
   utbetaling: UtbetalingData;
-  language: Language;
+  locale: Locale;
   utbetalingType: "kommende" | "tidligere";
 }
 
-const { utbetaling, language, utbetalingType } = Astro.props;
+const { utbetaling, locale, utbetalingType } = Astro.props;
 
 const containerStyling = {
   kommende: `${styles.container} ${styles.kommende}`,
@@ -30,10 +30,10 @@ const seDetaljerStyling = {
 <a class={containerStyling} href={`${UTBETALINGSOVERSIKT_URL}/utbetaling/${utbetaling.id}`}>
   <span class={styles.headingContainer} id={utbetalingType === "kommende" ? "kommende" : "tidligere"}>
     <Heading level="2" size="xsmall">
-      {utbetalingType === "kommende" ? text.tittelKommende[language] : text.tittelTidligere[language]}
+      {utbetalingType === "kommende" ? text.tittelKommende[locale] : text.tittelTidligere[locale]}
     </Heading>
     <BodyShort className={seDetaljerStyling} id={utbetalingType === "kommende" ? "kommende" : "tidligere"}>
-      {text.seDetaljer[language]}
+      {text.seDetaljer[locale]}
       <Chevron className={styles.chevron} fontSize="24px" aria-hidden={true} />
     </BodyShort>
   </span>
@@ -42,7 +42,7 @@ const seDetaljerStyling = {
   </Heading>
   <BodyShort
     >{
-      `${utbetaling.ytelse} — ${utbetalingType === "kommende" ? text.utbetales[language] : text.utbetalt[language]} ${formatToReadableDate(utbetaling.dato)}`
+      `${utbetaling.ytelse} — ${utbetalingType === "kommende" ? text.utbetales[locale] : text.utbetalt[locale]} ${formatToReadableDate(utbetaling.dato)}`
     }</BodyShort
   >
 </a>

--- a/src/features/utbetaling/fallback/UtbetalingFallback.astro
+++ b/src/features/utbetaling/fallback/UtbetalingFallback.astro
@@ -2,17 +2,17 @@
 import { UTBETALINGSOVERSIKT_URL } from "astro:env/server";
 import { Heading, Skeleton } from "@navikt/ds-react";
 import { text } from "@src/features/utbetaling/utbetalingText";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import style from "./UtbetalingFallback.module.css";
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 <div class={style.detaljer}>
   <div class={`${style.detaljerContainer}`}>
     <div class={style.heading}>
       <Heading level="2" size="xsmall">
-        {text.tittelUtbetalinger[language]}
+        {text.tittelUtbetalinger[locale]}
       </Heading>
     </div>
     <Skeleton width={116} height={28} />

--- a/src/features/utbetaling/ingen/IngenUtbetaling.astro
+++ b/src/features/utbetaling/ingen/IngenUtbetaling.astro
@@ -1,21 +1,21 @@
 ---
 import { BodyShort, Heading } from "@navikt/ds-react";
 import { text } from "@src/features/utbetaling/utbetalingText";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import styles from "./IngenUtbetaling.module.css";
 
 interface Props {
-  language: Language;
+  locale: Locale;
 }
 
-const { language } = Astro.props;
+const { locale } = Astro.props;
 ---
 
 <div>
   <div class={styles.contentContainer}>
-    <Heading level="2" size="xsmall">{text.tittelUtbetalinger[language]}</Heading>
+    <Heading level="2" size="xsmall">{text.tittelUtbetalinger[locale]}</Heading>
     <BodyShort className={styles.text}>
-      {text.ingen[language]}
+      {text.ingen[locale]}
     </BodyShort>
   </div>
 </div>

--- a/src/features/utbetaling/list/UtbetalingList.astro
+++ b/src/features/utbetaling/list/UtbetalingList.astro
@@ -5,25 +5,25 @@ import { BodyShort, Heading, Tag } from "@navikt/ds-react";
 import { text } from "@src/features/utbetaling/utbetalingText";
 import type { UtbetalingData } from "@src/features/utbetaling/utbetalingTypes";
 import { formatToReadableDate } from "@src/features/utbetaling/utbetalingUtils";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import styles from "./UtbetalingList.module.css";
 
 interface Props {
   kommende: UtbetalingData;
   tidligere: UtbetalingData;
-  language: Language;
+  locale: Locale;
 }
 
-const { kommende, tidligere, language } = Astro.props;
+const { kommende, tidligere, locale } = Astro.props;
 ---
 
 <div class={styles.wrapper}>
-  <Heading level="2" size="xsmall" className={styles.heading}>{text.tittelUtbetalinger[language]}</Heading>
+  <Heading level="2" size="xsmall" className={styles.heading}>{text.tittelUtbetalinger[locale]}</Heading>
   <a href={`${UTBETALINGSOVERSIKT_URL}/utbetaling/${kommende.id}`} class={styles.kommendeOgTidligere} id="kommende">
     <BodyShort className={styles.datoOgYtelse}>
       <span class={styles.datoOgTag}>
         {formatToReadableDate(kommende.dato)}
-        <Tag variant="success-moderate" size="small" className={styles.tag}>{text.tittelKommende[language]}</Tag>
+        <Tag variant="success-moderate" size="small" className={styles.tag}>{text.tittelKommende[locale]}</Tag>
       </span>
       <span class={styles.ytelse}>
         {kommende.ytelse}

--- a/src/features/utbetaling/se-alle/SeAlle.astro
+++ b/src/features/utbetaling/se-alle/SeAlle.astro
@@ -2,15 +2,15 @@
 import { UTBETALINGSOVERSIKT_URL } from "astro:env/server";
 import { ChevronRightIcon as Chevron } from "@navikt/aksel-icons";
 import { text } from "@src/features/utbetaling/utbetalingText";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import styles from "./SeAlle.module.css";
 
 interface Props {
-  language: Language;
+  locale: Locale;
   isKommende: boolean;
 }
 
-const { language, isKommende } = Astro.props;
+const { locale, isKommende } = Astro.props;
 ---
 
 <>
@@ -19,7 +19,7 @@ const { language, isKommende } = Astro.props;
     id="seAlle"
     class={isKommende ? `${styles.container} ${styles.kommende}` : `${styles.container} ${styles.tidligere}`}
   >
-    {text.alle[language]}
+    {text.alle[locale]}
     <Chevron className={styles.chevron} fontSize="24px" aria-hidden={true} />
   </a>
   <script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,14 +3,14 @@ import { MIN_SIDE_URL } from "astro:env/server";
 import { fetchDecoratorHtml } from "@navikt/nav-dekoratoren-moduler/ssr";
 import Authentication from "@src/shared/authentication/Authentication";
 import { getDecoratorEnvironment } from "@src/shared/utils/server/environment";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 import "./Layout.css";
 
 export interface Props {
   title: string;
 }
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 const { title } = Astro.props;
 
 const Decorator = await fetchDecoratorHtml({
@@ -18,7 +18,7 @@ const Decorator = await fetchDecoratorHtml({
   params: {
     context: "privatperson",
     breadcrumbs: [],
-    language: language,
+    language: locale,
     availableLanguages: [
       {
         locale: "nb",
@@ -43,7 +43,7 @@ const { DECORATOR_HEAD_ASSETS, DECORATOR_HEADER, DECORATOR_FOOTER, DECORATOR_SCR
 ---
 
 <!doctype html>
-<html lang={language}>
+<html lang={locale}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -18,15 +18,15 @@ import Content from "@src/shared/content/Content.astro";
 import Feilmelding from "@src/shared/feilmelding/Feilmelding";
 import Legacy from "@src/shared/legacy/Legacy";
 import Observability from "@src/shared/obersvability/Observability";
-import type { Language } from "@src/shared/utils/server/language";
+import type { Locale } from "@src/shared/utils/server/locale";
 
-const language = Astro.currentLocale as Language;
+const locale = Astro.currentLocale as Locale;
 ---
 
 <Layout title="Min side">
   <Content cls="min-side">
     <SubstantialInfo />
-    <Feilmelding language={language} client:only="react" />
+    <Feilmelding locale={locale} client:only="react" />
     <Personalia />
     <AlertIsland />
     <DinOversikt server:defer />

--- a/src/shared/feilmelding/Feilmelding.tsx
+++ b/src/shared/feilmelding/Feilmelding.tsx
@@ -1,21 +1,21 @@
 import { useStore } from "@nanostores/react";
 import { Alert } from "@navikt/ds-react";
 import { isErrorAtom } from "@src/shared/store/store.ts";
-import type { Language } from "@src/shared/utils/server/language.ts";
+import type { Locale } from "@src/shared/utils/server/locale.ts";
 import styles from "./Feilmelding.module.css";
 import { feilmeldingText } from "./feilmeldingText";
 
 interface Props {
-  language: Language;
+  locale: Locale;
 }
 
-const FeilMelding = ({ language }: Props) => {
+const FeilMelding = ({ locale }: Props) => {
   const isError = useStore(isErrorAtom);
 
   if (isError) {
     return (
       <Alert variant="error" className={styles["feilmelding"]}>
-        {feilmeldingText.feilmelding[language]}
+        {feilmeldingText.feilmelding[locale]}
       </Alert>
     );
   }

--- a/src/shared/legacy/legacyUtils.ts
+++ b/src/shared/legacy/legacyUtils.ts
@@ -1,12 +1,12 @@
 import type { PersonalizedContent } from "@src/features/din-oversikt/DinOversiktTypes";
 import { produktText } from "@src/features/din-oversikt/produktkort/ProduktText";
 import type { Microfrontend } from "@src/shared/microfrontends/microfrontendTypes";
-import type { Language } from "@src/shared/utils/server/language.ts";
+import type { Locale } from "@src/shared/utils/server/locale.ts";
 
-export const getProduktPropertiesLegacy = (language: Language, personalizedContent?: PersonalizedContent) => {
+export const getProduktPropertiesLegacy = (locale: Locale, personalizedContent?: PersonalizedContent) => {
   if (personalizedContent === undefined) return undefined;
 
-  const produktPropertiesMap = getProduktPropertiesMapLegacy(language);
+  const produktPropertiesMap = getProduktPropertiesMapLegacy(locale);
   const byKode = (a: string, b: string) => a.localeCompare(b);
   const toProduktProperties = (sakstema: string) => produktPropertiesMap[sakstema];
 
@@ -21,38 +21,38 @@ export const hasAktueltMicrofrontendsLegacy = (microfrontends: Microfrontend[]) 
 
 type ProduktProperties = { produktnavn: string; tittel: string };
 
-export function getProduktPropertiesMapLegacy(language: Language): Record<string, ProduktProperties> {
+export function getProduktPropertiesMapLegacy(locale: Locale): Record<string, ProduktProperties> {
   const sykefraværConfig: ProduktProperties = {
     produktnavn: "sykefravær",
-    tittel: produktText.sykefravær[language],
+    tittel: produktText.sykefravær[locale],
   };
 
   return {
     DAG: {
       produktnavn: "dagpenger",
-      tittel: produktText.dagpenger[language],
+      tittel: produktText.dagpenger[locale],
     },
     FOR: {
       produktnavn: "foreldrepenger",
-      tittel: produktText.foreldrepenger[language],
+      tittel: produktText.foreldrepenger[locale],
     },
     HJE: {
       produktnavn: "hjelpemidler",
-      tittel: produktText.hjelpemidler[language],
+      tittel: produktText.hjelpemidler[locale],
     },
     KOM: {
       produktnavn: "sosialhjelp",
-      tittel: produktText.sosialhjelp[language],
+      tittel: produktText.sosialhjelp[locale],
     },
     PEN: {
       produktnavn: "pensjon",
-      tittel: produktText.pensjon[language],
+      tittel: produktText.pensjon[locale],
     },
     SYK: sykefraværConfig,
     SYM: sykefraværConfig,
     UFO: {
       produktnavn: "uføretrygd",
-      tittel: produktText.uføretrygd[language],
+      tittel: produktText.uføretrygd[locale],
     },
   };
 }

--- a/src/shared/microfrontends/Microfrontend.astro
+++ b/src/shared/microfrontends/Microfrontend.astro
@@ -8,10 +8,10 @@ import type { Microfrontend } from "./microfrontendTypes";
 
 interface Props {
   microfrontend: Microfrontend;
-  language: string;
+  locale: string;
 }
 
-const { microfrontend, language } = Astro.props;
+const { microfrontend, locale } = Astro.props;
 
 const audience = getAudience(microfrontend.appname, microfrontend.namespace);
 const oboToken = await getOboToken(Astro.locals.token, audience);
@@ -20,13 +20,13 @@ let isError = false;
 let html = "";
 
 try {
-  html = await fetchMicrofrontend(oboToken, `${microfrontend.url}/${language}`);
+  html = await fetchMicrofrontend(oboToken, `${microfrontend.url}/${locale}`);
 } catch (error) {
   logger.error(
     `Failed to fetch microfrontend: ${microfrontend.appname} with url: ${microfrontend.url}. Error: ${error}`,
   );
   isError = true;
-  html = await fetchMicrofrontend(oboToken, `${microfrontend.url}/${language}/${microfrontend.fallback}`);
+  html = await fetchMicrofrontend(oboToken, `${microfrontend.url}/${locale}/${microfrontend.fallback}`);
 }
 ---
 

--- a/src/shared/utils/server/language.ts
+++ b/src/shared/utils/server/language.ts
@@ -1,1 +1,0 @@
-export type Language = "nb" | "nn" | "en";

--- a/src/shared/utils/server/locale.ts
+++ b/src/shared/utils/server/locale.ts
@@ -1,0 +1,1 @@
+export type Locale = "nb" | "nn" | "en";


### PR DESCRIPTION
## Hva er gjort
- erstattet delt type `Language` med `Locale` (`src/shared/utils/server/locale.ts`)
- oppdatert alle imports/signaturer/props i `src/**` fra `Language`/`language` til `Locale`/`locale` der det representerer locale
- refaktorert forekomster av `Astro.currentLocale as Language` til `Astro.currentLocale as Locale`
- oppdatert callsites for props i Astro/React-komponenter (inkl. `Microfrontend`, `Meldekort`, `Feilmelding`)

## Verifisering
- `pnpm run typecheck`
- `pnpm run build`

Closes #602
