### PR TITLE
refactor(locale): introduser getLocale-hjelper for currentLocale

### DIFF
--- a/.github/skills/pull-request/SKILL.md
+++ b/.github/skills/pull-request/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: pull-request
+description: "PR-oppretting og -oppdatering — semantisk tittel, kort beskrivelse, issue-kobling, teststatus, risiko, sjekkliste og reviewer-kontekst. Brukes via /pull-request ved nye eller oppdaterte PR-er."
+---
+
+# Pull request
+
+Opprett konsistente, godt strukturerte pull requests som kobles til issues og følger teamets arbeidsflyt.
+
+## PR-tittel
+
+Bruk semantisk commit-format:
+
+```
+type(scope): kort beskrivelse
+```
+
+- **Typer:** `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `style`
+- **Scope:** Modul eller domene som endres
+
+## PR-tekst
+
+Repoet har en PR-template i `.github/PULL_REQUEST_TEMPLATE.md` som automatisk forhåndsfyller teksten når du oppretter en PR. Fyll inn seksjonene i malen.
+
+For ikke-trivielle endringer bør teksten kort oppsummere:
+- hva som ble endret
+- issue-kobling
+- hva som ble verifisert (build/typecheck/test/lint)
+- eventuelle merknader fra review/inspeksjon
+
+## Issue-kobling
+
+| Situasjon | I PR-body |
+|-----------|-----------|
+| Issue løst fullstendig | `Closes #123` |
+| Delvis arbeid, issue fortsatt åpent | `Relates to #123` |
+| Del av epic | `Closes #123` + `Del av epic: #100` |
+| Ingen issue | Skriv motivasjon direkte i beskrivelsen |
+
+## Opprettelse
+
+### MCP (foretrukket)
+
+Bruk tilgjengelig PR-verktøy for å opprette PR med tittel og tekst.
+
+### Fallback (gh CLI)
+
+```bash
+gh pr create \
+  --repo navikt/REPO_NAVN \
+  --title "type(scope): beskrivelse" \
+  --body "BODY"
+```
+
+### Auto-merge (squash)
+
+Etter opprettelse:
+```bash
+gh pr merge --auto --squash
+```

--- a/src/features/aktuelt/Aktuelt.astro
+++ b/src/features/aktuelt/Aktuelt.astro
@@ -4,7 +4,7 @@ import { BodyShort, Skeleton } from "@navikt/ds-react";
 import ClientError from "@src/shared/client-error/ClientError";
 import Microfrontend from "@src/shared/microfrontends/Microfrontend.astro";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Locale } from "@src/shared/utils/server/locale.ts";
+import { getLocale } from "@src/shared/utils/server/locale.ts";
 import logger from "@src/shared/utils/server/logger.ts";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import style from "./Aktuelt.module.css";
@@ -13,7 +13,7 @@ import type { Aktuelt } from "./aktueltTypes";
 
 const audience = getAudience("tms-mikrofrontend-selector");
 const oboToken = await getOboToken(Astro.locals.token, audience);
-const locale = (Astro.currentLocale ?? "nb") as Locale;
+const locale = getLocale(Astro.currentLocale);
 
 let aktuelt: Aktuelt = { offerStepup: false, microfrontends: [] };
 let isError = false;

--- a/src/features/alert-island/utkast/Utkast.astro
+++ b/src/features/alert-island/utkast/Utkast.astro
@@ -3,7 +3,7 @@ import { UTKAST_API_URL, UTKAST_URL } from "astro:env/server";
 import ClientError from "@src/shared/client-error/ClientError";
 import { MultiStatusError } from "@src/shared/utils/server/error";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import UtkastIkon from "./assets/UtkastIkon.tsx";
@@ -29,7 +29,7 @@ try {
   isError = true;
 }
 
-const locale = (Astro.currentLocale ?? "nb") as Locale;
+const locale = getLocale(Astro.currentLocale);
 const antall = data ? data.antall : 0;
 const hasUtkast = antall > 0;
 const ingress = antall === 1 ? text.soknad[locale] : text.soknader[locale](antall);

--- a/src/features/alert-island/varsler/Varsler.astro
+++ b/src/features/alert-island/varsler/Varsler.astro
@@ -3,7 +3,7 @@ import { VARSEL_API_URL, VARSLER_URL } from "astro:env/server";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import IngenVarslerIkon from "./assets/IngenVarslerIkon";
@@ -30,7 +30,7 @@ const oppgaver = data.oppgaver || 0;
 const beskjeder = data.beskjeder + data.innbokser;
 const varsler = beskjeder + oppgaver;
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 const oppgaveText = oppgaveSingular(oppgaver) ? text.oppgave[locale] : text.oppgaver[locale];
 const beskjedText = beskjedSingular(beskjeder) ? text.beskjed[locale] : text.beskjeder[locale];
 ---

--- a/src/features/din-oversikt/DinOversikt.astro
+++ b/src/features/din-oversikt/DinOversikt.astro
@@ -6,7 +6,7 @@ import Microfrontend from "@src/shared/microfrontends/Microfrontend.astro";
 import MicrofrontendSkeleton from "@src/shared/microfrontends/MicrofrontendSkeleton.astro";
 import { MultiStatusError } from "@src/shared/utils/server/error";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import styles from "./DinOversikt.module.css";
@@ -20,7 +20,7 @@ import { getShowDinOversikt } from "./useOversikt.ts";
 
 const audience = getAudience("tms-mikrofrontend-selector");
 const oboToken = await getOboToken(Astro.locals.token, audience);
-const locale = (Astro.currentLocale ?? "nb") as Locale;
+const locale = getLocale(Astro.currentLocale);
 
 let isError = false;
 let personalizedContent: PersonalizedContent = {

--- a/src/features/dokumenter/Dokumenter.astro
+++ b/src/features/dokumenter/Dokumenter.astro
@@ -5,7 +5,7 @@ import { BodyLong, BodyShort, Heading } from "@navikt/ds-react";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import styles from "./Dokumenter.module.css";
@@ -31,7 +31,7 @@ try {
 }
 
 const hasIngenDokumenter = data.length === 0;
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 {isError && <ClientError client:only="react" />}

--- a/src/features/dokumenter/fallback/DokumenterFallback.astro
+++ b/src/features/dokumenter/fallback/DokumenterFallback.astro
@@ -1,9 +1,9 @@
 ---
 import { Heading, Skeleton } from "@navikt/ds-react";
 import { text } from "@src/features/dokumenter/dokumenterText";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 <div>

--- a/src/features/innboks/Innboks.astro
+++ b/src/features/innboks/Innboks.astro
@@ -5,7 +5,7 @@ import { BodyLong, Heading } from "@navikt/ds-react";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import styles from "./Innboks.module.css";
@@ -27,7 +27,7 @@ try {
 
 const innbokser = data.innbokser;
 const type = innbokser > 0 ? "NyMelding" : "IngenNyMelding";
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 {isError && <ClientError client:only="react" />}

--- a/src/features/innboks/fallback/InnboksFallback.astro
+++ b/src/features/innboks/fallback/InnboksFallback.astro
@@ -3,9 +3,9 @@ import { INNBOKS_URL } from "astro:env/server";
 import { BodyLong, BodyShort, Skeleton } from "@navikt/ds-react";
 import styles from "@src/features/innboks/Innboks.module.css";
 import { text } from "@src/features/innboks/innboksText";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 <div class={styles.container}>

--- a/src/features/innloggede-tjenester/InnloggedeTjenester.astro
+++ b/src/features/innloggede-tjenester/InnloggedeTjenester.astro
@@ -1,12 +1,12 @@
 ---
 import { BodyShort, Heading } from "@navikt/ds-react";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import styles from "./InnloggedeTjenester.module.css";
 import { text } from "./innloggedeTjenesterText";
 import { annetLenker, hjelpemidlerLenker, jobbLenker, personopplysningLenker } from "./innloggedeTjenesterUrls";
 import InnloggedeTjensterSection from "./section/InnloggedeTjenesterSection.astro";
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 const isEnglish = locale === "en";
 ---
 

--- a/src/features/innloggede-tjenester/section/InnloggedeTjenesterSection.astro
+++ b/src/features/innloggede-tjenester/section/InnloggedeTjenesterSection.astro
@@ -3,7 +3,7 @@ import { ChevronRightIcon as Chevron } from "@navikt/aksel-icons";
 import { BodyShort, Detail } from "@navikt/ds-react";
 import type { Lenke } from "@src/features/innloggede-tjenester/innloggedeTjenesterUrls";
 import LinkWithAmplitude from "@src/features/innloggede-tjenester/link/LinkWithAmplitude";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import style from "./InnloggedeTjensterSection.module.css";
 
 interface Props {
@@ -11,7 +11,7 @@ interface Props {
   tittel: string;
 }
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 const { lenker, tittel } = Astro.props;
 ---
 

--- a/src/features/personalia/Personalia.astro
+++ b/src/features/personalia/Personalia.astro
@@ -1,10 +1,10 @@
 ---
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import Navn from "./navn/Navn.astro";
 import style from "./Personalia.module.css";
 import { text } from "./personaliaText";
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 <div class={style.container}>

--- a/src/features/substantial-info/SubstantialInfo.astro
+++ b/src/features/substantial-info/SubstantialInfo.astro
@@ -1,9 +1,9 @@
 ---
 import { Alert, BodyShort, Heading, Link } from "@navikt/ds-react";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import { text } from "./substantialInfoText";
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 const isSubstantial: boolean = Astro.locals.isSubstantial;
 ---
 

--- a/src/features/utbetaling/Utbetaling.astro
+++ b/src/features/utbetaling/Utbetaling.astro
@@ -3,7 +3,7 @@ import { UTBETALINGSOVERSIKT_API_URL } from "astro:env/server";
 import ClientError from "@src/shared/client-error/ClientError";
 import PersonalContentLogger from "@src/shared/legacy/PersonalContentLogger";
 import { fetchData } from "@src/shared/utils/server/fetch";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import logger from "@src/shared/utils/server/logger";
 import { getAudience, getOboToken } from "@src/shared/utils/server/token";
 import EnkelUtbetaling from "./enkel/EnkelUtbetaling.astro";
@@ -27,7 +27,7 @@ try {
   isError = true;
 }
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 {isError && <ClientError client:only="react" />}

--- a/src/features/utbetaling/fallback/UtbetalingFallback.astro
+++ b/src/features/utbetaling/fallback/UtbetalingFallback.astro
@@ -2,10 +2,10 @@
 import { UTBETALINGSOVERSIKT_URL } from "astro:env/server";
 import { Heading, Skeleton } from "@navikt/ds-react";
 import { text } from "@src/features/utbetaling/utbetalingText";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import style from "./UtbetalingFallback.module.css";
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 <div class={style.detaljer}>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,14 +3,14 @@ import { MIN_SIDE_URL } from "astro:env/server";
 import { fetchDecoratorHtml } from "@navikt/nav-dekoratoren-moduler/ssr";
 import Authentication from "@src/shared/authentication/Authentication";
 import { getDecoratorEnvironment } from "@src/shared/utils/server/environment";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 import "./Layout.css";
 
 export interface Props {
   title: string;
 }
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 const { title } = Astro.props;
 
 const Decorator = await fetchDecoratorHtml({

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -18,9 +18,9 @@ import Content from "@src/shared/content/Content.astro";
 import Feilmelding from "@src/shared/feilmelding/Feilmelding";
 import Legacy from "@src/shared/legacy/Legacy";
 import Observability from "@src/shared/obersvability/Observability";
-import type { Locale } from "@src/shared/utils/server/locale";
+import { getLocale } from "@src/shared/utils/server/locale";
 
-const locale = Astro.currentLocale as Locale;
+const locale = getLocale(Astro.currentLocale);
 ---
 
 <Layout title="Min side">

--- a/src/shared/utils/server/locale.ts
+++ b/src/shared/utils/server/locale.ts
@@ -1,1 +1,5 @@
 export type Locale = "nb" | "nn" | "en";
+
+export function getLocale(currentLocale: string | undefined): Locale {
+  return (currentLocale ?? "nb") as Locale;
+}


### PR DESCRIPTION
## Hva som ble endret

Erstatter det gjentatte mønsteret `(Astro.currentLocale ?? "nb") as Locale` med en delt hjelpefunksjon `getLocale()` i `src/shared/utils/server/locale.ts`. Alle features og layout/sider bruker nå hjelperen i stedet for å duplisere fallback-logikken og type-castet.

- Ny `getLocale(currentLocale: string | undefined): Locale` i `shared/utils/server/locale.ts`.
- 16 `.astro`-filer oppdatert til å importere og bruke `getLocale(Astro.currentLocale)`.

## Issue-kobling

Ingen issue — ren intern refaktorering for å redusere duplisering.

## Verifisert

- `pnpm run typecheck`: 0 errors (kun pre-eksisterende, urelaterte hints).
- `biome check` via pre-commit-hook: passerte (6 pre-eksisterende `any`-warnings, urelatert).

## Merknader

Branchen inneholder også en separat commit som legger til `pull-request`-skillen (`.github/skills/pull-request/SKILL.md`), urelatert til locale-refaktoreringen.