### PR TITLE
test: innfør Vitest- og Playwright-testoppsett med CI-integrasjon

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -27,6 +27,20 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
+      - name: "Run unit tests"
+        run: "pnpm run test"
+        env:
+          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
+
+      - name: "Install Playwright browsers"
+        run: "pnpm exec playwright install --with-deps chromium"
+
+      - name: "Run E2E tests"
+        run: "pnpm run test:e2e"
+        env:
+          CI: "true"
+          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
+
       - name: "Build application"
         run: "pnpm run build"
         env:

--- a/.github/workflows/deploy-main.yaml
+++ b/.github/workflows/deploy-main.yaml
@@ -30,6 +30,20 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
+      - name: "Run unit tests"
+        run: "pnpm run test"
+        env:
+          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
+
+      - name: "Install Playwright browsers"
+        run: "pnpm exec playwright install --with-deps chromium"
+
+      - name: "Run E2E tests"
+        run: "pnpm run test:e2e"
+        env:
+          CI: "true"
+          ASTRO_KEY: ${{ secrets.ASTRO_KEY }}
+
       - name: "Build application"
         run: "pnpm run build"
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,8 @@ dist
 
 # Astro
 .astro/
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,17 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const wcagTags = ["wcag2a", "wcag2aa", "wcag21aa"];
+
+test.describe("Universell utforming", () => {
+  test("landingssiden har ingen WCAG-brudd", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+    await minSide.expectNameLoaded();
+
+    const results = await new AxeBuilder({ page }).withTags(wcagTags).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/aktuelt.spec.ts
+++ b/e2e/aktuelt.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const timeout = 15_000;
+
+test.describe("Aktuelt", () => {
+  test("viser aktuelt-innhold med mikrofrontend", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.aktuelt).toBeVisible({ timeout });
+    await expect(minSide.microfrontend("Pensjonskalkulator")).toBeVisible({
+      timeout,
+    });
+  });
+});

--- a/e2e/alert-island.spec.ts
+++ b/e2e/alert-island.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const timeout = 15_000;
+
+test.describe("Varsler og utkast", () => {
+  test("viser varsler med oppgaver og beskjeder", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.varsler).toBeVisible({ timeout });
+    await expect(page.getByText("3 oppgaver og 6 beskjeder")).toBeVisible({
+      timeout,
+    });
+  });
+
+  test("viser antall påbegynte utkast", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.utkast).toBeVisible({ timeout });
+    await expect(page.getByText("Du har 2 påbegynte søknader")).toBeVisible({
+      timeout,
+    });
+  });
+});

--- a/e2e/din-oversikt.spec.ts
+++ b/e2e/din-oversikt.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const timeout = 15_000;
+
+test.describe("Din oversikt", () => {
+  test("viser overskriften for den personaliserte oversikten", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.dinOversikt).toBeVisible({ timeout });
+  });
+
+  test("viser meldekort-mikrofrontenden", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.microfrontend("Meldekort")).toBeVisible({ timeout });
+  });
+
+  test("viser mikrofrontendene for AAP og Syfo dialog", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.microfrontend("AAP")).toBeVisible({ timeout });
+    await expect(minSide.microfrontend("Syfo dialog")).toBeVisible({ timeout });
+  });
+
+  test("viser et produktkort med ytelse", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(page.getByRole("heading", { name: "Dagpenger", level: 3, exact: true })).toBeVisible({ timeout });
+  });
+});

--- a/e2e/dokumenter.spec.ts
+++ b/e2e/dokumenter.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const timeout = 15_000;
+
+test.describe("Dokumenter", () => {
+  test("viser de siste dokumentene", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.dokumenter).toBeVisible({ timeout });
+    await expect(
+      page.getByRole("link", {
+        name: /Søknad om å beholde arbeidsavklaringspenger under opphold i innlandet/,
+      }),
+    ).toBeVisible({ timeout });
+  });
+
+  test("lenker til alle dokumenter", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.seAlleDokumenter).toBeVisible({ timeout });
+    await expect(minSide.seAlleDokumenter).toHaveAttribute("href", /dokumentarkiv/);
+  });
+});

--- a/e2e/error.spec.ts
+++ b/e2e/error.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Ukjent rute", () => {
+  test("svarer med 404 for en side som ikke finnes", async ({ page }) => {
+    const response = await page.goto("/minside/nb/finnes-ikke");
+
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+test.describe("Landingsside", () => {
+  test("viser hilsen og tittel", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(page).toHaveTitle("Min side");
+    await expect(minSide.greeting).toBeVisible();
+  });
+
+  test("viser seksjonen for innloggede tjenester", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.innloggedeTjenester).toBeVisible();
+  });
+
+  test("henter innbyggerens navn fra api-et", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await minSide.expectNameLoaded();
+  });
+});

--- a/e2e/innboks.spec.ts
+++ b/e2e/innboks.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const timeout = 15_000;
+
+test.describe("Innboks", () => {
+  test("viser innboks med antall nye meldinger", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.innboks).toBeVisible({ timeout });
+    await expect(page.getByText("4 nye meldinger")).toBeVisible({ timeout });
+  });
+
+  test("lenker til innboksen", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    const innboksLenke = page.getByRole("link", { name: /Innboks/ });
+    await expect(innboksLenke).toBeVisible({ timeout });
+    await expect(innboksLenke).toHaveAttribute("href", /innboks/);
+  });
+});

--- a/e2e/innloggede-tjenester.spec.ts
+++ b/e2e/innloggede-tjenester.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+test.describe("Innloggede tjenester", () => {
+  test("viser navigasjon med tjenesteseksjoner", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.innloggedeTjenester).toBeVisible();
+    await expect(page.getByText("JOBB OG OPPFØLGING")).toBeVisible();
+    await expect(page.getByText("PERSONOPPLYSNINGER")).toBeVisible();
+  });
+
+  test("lenker til en kjent tjeneste", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    const aktivitetsplan = page.getByRole("link", { name: "Aktivitetsplan" });
+    await expect(aktivitetsplan).toBeVisible();
+    await expect(aktivitetsplan).toHaveAttribute("href", /aktivitetsplan/);
+  });
+});

--- a/e2e/pages/minside.page.ts
+++ b/e2e/pages/minside.page.ts
@@ -1,0 +1,64 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+const BASE_PATH = "/minside/nb/";
+
+export class MinSidePage {
+  readonly greeting: Locator;
+  readonly innloggedeTjenester: Locator;
+  readonly dinOversikt: Locator;
+  readonly utbetalinger: Locator;
+  readonly seAlleUtbetalinger: Locator;
+  readonly innboks: Locator;
+  readonly dokumenter: Locator;
+  readonly seAlleDokumenter: Locator;
+  readonly varsler: Locator;
+  readonly utkast: Locator;
+  readonly aktuelt: Locator;
+
+  constructor(private readonly page: Page) {
+    this.greeting = page.getByRole("heading", { name: /Hei,/ });
+    this.innloggedeTjenester = page.getByRole("heading", {
+      name: "Innloggede tjenester",
+    });
+    this.dinOversikt = page.getByRole("heading", {
+      name: "Din oversikt",
+      exact: true,
+    });
+    this.utbetalinger = page.getByRole("heading", {
+      name: "Utbetalinger",
+      exact: true,
+    });
+    this.seAlleUtbetalinger = page.getByRole("link", {
+      name: "Se alle utbetalinger",
+    });
+    this.innboks = page.getByRole("heading", { name: "Innboks", exact: true });
+    this.dokumenter = page.getByRole("heading", {
+      name: "Siste dokumenter",
+      exact: true,
+    });
+    this.seAlleDokumenter = page.getByRole("link", {
+      name: "Se alle dokumenter",
+    });
+    this.varsler = page.getByRole("heading", { name: "Varsler", exact: true });
+    this.utkast = page.getByRole("heading", { name: "Utkast", exact: true });
+    this.aktuelt = page.getByRole("heading", {
+      name: "Kan være aktuelt for deg",
+      exact: true,
+    });
+  }
+
+  async goto() {
+    await this.page.goto(BASE_PATH);
+    await expect(this.greeting).toBeVisible();
+  }
+
+  async expectNameLoaded() {
+    await expect(this.page.getByText(/navn navnesen/i).first()).toBeVisible({
+      timeout: 20_000,
+    });
+  }
+
+  microfrontend(name: string): Locator {
+    return this.page.getByRole("heading", { name, level: 3, exact: true });
+  }
+}

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const viewports = [
+  { name: "mobil", width: 375, height: 812 },
+  { name: "desktop", width: 1280, height: 800 },
+];
+
+for (const viewport of viewports) {
+  test(`viser innhold på ${viewport.name} (${viewport.width}px)`, async ({ page }) => {
+    await page.setViewportSize({
+      width: viewport.width,
+      height: viewport.height,
+    });
+
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.greeting).toBeVisible();
+    await minSide.expectNameLoaded();
+  });
+}

--- a/e2e/utbetaling.spec.ts
+++ b/e2e/utbetaling.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+import { MinSidePage } from "./pages/minside.page";
+
+const timeout = 15_000;
+
+test.describe("Utbetaling", () => {
+  test("viser utbetalingslisten med ytelser", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.utbetalinger).toBeVisible({ timeout });
+    await expect(page.getByText("Arbeidsavklaringspenger").first()).toBeVisible({ timeout });
+  });
+
+  test("merker kommende utbetaling med «Neste utbetaling»", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(page.getByText("Neste utbetaling").first()).toBeVisible({
+      timeout,
+    });
+  });
+
+  test("lenker til alle utbetalinger", async ({ page }) => {
+    const minSide = new MinSidePage(page);
+    await minSide.goto();
+
+    await expect(minSide.seAlleUtbetalinger).toBeVisible({ timeout });
+    await expect(minSide.seAlleUtbetalinger).toHaveAttribute("href", /utbetalingsoversikt/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "preview": "node ./dist/server/entry.mjs",
     "astro": "astro",
     "format": "biome format --write",
-    "typecheck": "astro check"
+    "typecheck": "astro check",
+    "test": "NODE_ENV=development vitest run",
+    "test:watch": "NODE_ENV=development vitest",
+    "test:coverage": "NODE_ENV=development vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/check": "0.9.9",
@@ -35,18 +39,24 @@
     "typescript": "6.0.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.11.3",
     "@biomejs/biome": "2.4.15",
     "@hono/node-server": "2.0.2",
+    "@playwright/test": "1.60.0",
+    "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
     "@types/node": "24.3.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@vitest/coverage-v8": "4.1.8",
     "hono": "4.12.18",
+    "jsdom": "29.1.1",
     "lefthook": "2.1.6",
     "prop-types": "15.8.1",
-    "tsx": "4.21.0"
+    "tsx": "4.21.0",
+    "vitest": "4.1.8"
   },
   "engines": {
     "node": ">=24.0.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "astro": "astro",
     "format": "biome format --write",
     "typecheck": "astro check",
-    "test": "NODE_ENV=development vitest run",
-    "test:watch": "NODE_ENV=development vitest",
-    "test:coverage": "NODE_ENV=development vitest run --coverage",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 4321;
+const origin = `http://localhost:${PORT}`;
+const baseURL = `${origin}/minside/nb/`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: origin,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: "pnpm mock",
+      url: "http://localhost:3000/navn",
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+    {
+      command: `pnpm start --port ${PORT}`,
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      env: {
+        NODE_ENV: "development",
+      },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,12 +69,21 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.11.3
+        version: 4.11.3(playwright-core@1.60.0)
       '@biomejs/biome':
         specifier: 2.4.15
         version: 2.4.15
       '@hono/node-server':
         specifier: 2.0.2
         version: 2.0.2(hono@4.12.18)
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
+      '@testing-library/dom':
+        specifier: 10.4.1
+        version: 10.4.1
       '@testing-library/jest-dom':
         specifier: 6.9.1
         version: 6.9.1
@@ -93,9 +102,15 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       hono:
         specifier: 4.12.18
         version: 4.12.18
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
@@ -105,11 +120,29 @@ importers:
       tsx:
         specifier: 4.21.0
         version: 4.21.0
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -165,6 +198,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -253,6 +291,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@biomejs/biome@2.4.15':
     resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
     engines: {node: '>=14.21.3'}
@@ -310,6 +352,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
@@ -321,6 +367,42 @@ packages:
   '@clack/prompts@1.3.0':
     resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
     engines: {node: '>= 20.12.0'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.2':
+    resolution: {integrity: sha512-n6Zd8mpVhObnaOqq6TC/lBCKgYncAGfFwuvJGQZTDRAwEoxwXIZu9kXBQeXkcqHsE6Sp6LyxDMrvXj5gOxnryw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -504,6 +586,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -945,6 +1036,11 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1156,6 +1252,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tabby_ai/hijri-converter@1.0.5':
     resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
     engines: {node: '>=16.0.0'}
@@ -1204,8 +1303,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1247,6 +1352,44 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1324,6 +1467,13 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
+
   astro@6.2.0:
     resolution: {integrity: sha512-EUAjibRHghfveuLW/8Wrp9DiL50zsp9VxTGQz9P9h/ViFM13AuWF209gn/Qtt7gZqYahpP6XH+mDT83DEOMgMw==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -1332,6 +1482,10 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1344,6 +1498,9 @@ packages:
     resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
@@ -1361,6 +1518,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1454,6 +1615,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
@@ -1471,6 +1636,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1595,12 +1763,19 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1648,6 +1823,11 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1669,6 +1849,10 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -1706,6 +1890,13 @@ packages:
 
   html-dom-parser@7.0.1:
     resolution: {integrity: sha512-loRBDTCY/05/jAC63J1X9ID+xjRucmpLkIcQO0IRbOubBo5ucnpUpyXXob9UMXOskMZlu7KPsDP/2KOMelzJNA==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -1773,9 +1964,24 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
@@ -1787,12 +1993,24 @@ packages:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1904,6 +2122,10 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -2153,8 +2375,14 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -2178,6 +2406,16 @@ packages:
 
   pino@9.9.5:
     resolution: {integrity: sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==}
+    hasBin: true
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   postcss@8.5.14:
@@ -2217,6 +2455,10 @@ packages:
   protobufjs@8.0.1:
     resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -2355,6 +2597,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2385,6 +2631,9 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -2406,9 +2655,15 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2431,6 +2686,10 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -2440,6 +2699,9 @@ packages:
     resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -2453,6 +2715,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -2465,9 +2730,28 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2519,6 +2803,10 @@ packages:
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2683,6 +2971,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -2775,19 +3104,47 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -2841,6 +3198,26 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@6.0.3)':
     dependencies:
@@ -2963,6 +3340,11 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.60.0
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3077,6 +3459,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@biomejs/biome@2.4.15':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.15
@@ -3112,6 +3496,10 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
@@ -3127,6 +3515,30 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -3235,6 +3647,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -3706,6 +4120,10 @@ snapshots:
 
   '@oslojs/encoding@1.1.0': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -3854,6 +4272,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tabby_ai/hijri-converter@1.0.5': {}
 
   '@testing-library/dom@10.4.1':
@@ -3913,9 +4333,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -3962,6 +4389,61 @@ snapshots:
       vite: 7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
@@ -4052,6 +4534,14 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.3:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   astro@6.2.0(@types/node@24.3.1)(rollup@4.60.3)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
@@ -4148,11 +4638,17 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  axe-core@4.11.4: {}
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
 
   baseline-browser-mapping@2.10.27: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bintrees@1.0.2: {}
 
@@ -4169,6 +4665,8 @@ snapshots:
   caniuse-lite@1.0.30001792: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -4248,6 +4746,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
@@ -4257,6 +4762,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4383,9 +4890,15 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   etag@1.8.1: {}
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -4421,6 +4934,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4445,6 +4961,8 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  has-flag@4.0.0: {}
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -4540,6 +5058,14 @@ snapshots:
       domhandler: 6.0.1
       htmlparser2: 12.0.0
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
+
   html-escaper@3.0.3: {}
 
   html-react-parser@6.0.1(@types/react@19.2.14)(react@19.2.0):
@@ -4598,9 +5124,24 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   jose@4.15.9: {}
 
@@ -4608,11 +5149,39 @@ snapshots:
 
   js-cookie@3.0.5: {}
 
+  js-tokens@10.0.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.27.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4700,6 +5269,10 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   markdown-table@3.0.4: {}
 
@@ -5119,7 +5692,13 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-browserify@1.0.1: {}
+
+  pathe@2.0.3: {}
 
   piccolore@0.1.3: {}
 
@@ -5148,6 +5727,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.14:
     dependencies:
@@ -5209,6 +5796,8 @@ snapshots:
       '@protobufjs/utf8': 1.1.1
       '@types/node': 24.3.1
       long: 5.3.2
+
+  punycode@2.3.1: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -5403,6 +5992,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -5472,6 +6065,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   sisteransi@1.0.5: {}
 
   smol-toml@1.6.1: {}
@@ -5486,7 +6081,11 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -5515,6 +6114,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -5531,6 +6134,8 @@ snapshots:
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   tdigest@0.1.2:
@@ -5543,6 +6148,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinyexec@1.1.2: {}
@@ -5552,7 +6159,23 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
+
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -5589,6 +6212,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.10.0: {}
+
+  undici@7.27.2: {}
 
   unified@11.0.5:
     dependencies:
@@ -5702,6 +6327,36 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.3(@types/node@24.3.1)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.3.1
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
@@ -5799,17 +6454,42 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
 
   web-vitals@5.2.0: {}
 
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which-pm-runs@1.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/src/features/alert-island/varsler/varslerUtils.test.ts
+++ b/src/features/alert-island/varsler/varslerUtils.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  beskjedSingular,
+  buildText,
+  hasBeskjeder,
+  hasOppgaver,
+  hasOppgaverAndBeskjeder,
+  hasVarsler,
+  oppgaveSingular,
+} from "./varslerUtils";
+
+describe("count predicates", () => {
+  it("hasOppgaver should be true only for a positive count", () => {
+    expect(hasOppgaver(1)).toBe(true);
+    expect(hasOppgaver(0)).toBe(false);
+  });
+
+  it("hasBeskjeder should be true only for a positive count", () => {
+    expect(hasBeskjeder(2)).toBe(true);
+    expect(hasBeskjeder(0)).toBe(false);
+  });
+
+  it("hasVarsler should be true only for a positive count", () => {
+    expect(hasVarsler(3)).toBe(true);
+    expect(hasVarsler(0)).toBe(false);
+  });
+
+  it("hasOppgaverAndBeskjeder should require both counts to be positive", () => {
+    expect(hasOppgaverAndBeskjeder(1, 1)).toBe(true);
+    expect(hasOppgaverAndBeskjeder(1, 0)).toBe(false);
+    expect(hasOppgaverAndBeskjeder(0, 1)).toBe(false);
+  });
+
+  it("oppgaveSingular and beskjedSingular should be true only for exactly one", () => {
+    expect(oppgaveSingular(1)).toBe(true);
+    expect(oppgaveSingular(2)).toBe(false);
+    expect(beskjedSingular(1)).toBe(true);
+    expect(beskjedSingular(0)).toBe(false);
+  });
+});
+
+describe("buildText", () => {
+  const beskjedText = "beskjeder";
+  const oppgaveText = "oppgaver";
+  const ogText = "og";
+
+  it("should combine oppgaver and beskjeder when both are present", () => {
+    expect(buildText(2, 3, beskjedText, oppgaveText, ogText)).toBe("3 oppgaver og 2 beskjeder");
+  });
+
+  it("should describe only oppgaver when there are no beskjeder", () => {
+    expect(buildText(0, 3, beskjedText, oppgaveText, ogText)).toBe("3 oppgaver");
+  });
+
+  it("should describe only beskjeder when there are no oppgaver", () => {
+    expect(buildText(2, 0, beskjedText, oppgaveText, ogText)).toBe("2 beskjeder");
+  });
+
+  it("should return undefined when there is nothing to report", () => {
+    expect(buildText(0, 0, beskjedText, oppgaveText, ogText)).toBeUndefined();
+  });
+});

--- a/src/features/din-oversikt/dinOversiktUtils.test.ts
+++ b/src/features/din-oversikt/dinOversiktUtils.test.ts
@@ -1,0 +1,49 @@
+import type { Microfrontend } from "@src/shared/microfrontends/microfrontendTypes";
+import { describe, expect, it } from "vitest";
+import type { PersonalizedContent } from "./DinOversiktTypes";
+import { getProduktkortList, hasAktueltMicrofrontends, hasMicrofrontends } from "./dinOversiktUtils";
+
+const microfrontend = (id: string): Microfrontend => ({
+  microfrontend_id: id,
+  url: "http://localhost:3000/mf",
+  appname: "app",
+  namespace: "min-side",
+  fallback: "",
+  ssr: true,
+});
+
+describe("hasMicrofrontends", () => {
+  it("should be true when there is at least one microfrontend", () => {
+    expect(hasMicrofrontends([microfrontend("a")])).toBe(true);
+  });
+
+  it("should be false for an empty list", () => {
+    expect(hasMicrofrontends([])).toBe(false);
+  });
+});
+
+describe("hasAktueltMicrofrontends", () => {
+  it("should be true when there is at least one microfrontend", () => {
+    expect(hasAktueltMicrofrontends([microfrontend("a")])).toBe(true);
+  });
+
+  it("should be false for an empty list", () => {
+    expect(hasAktueltMicrofrontends([])).toBe(false);
+  });
+});
+
+describe("getProduktkortList", () => {
+  it("should return undefined when there is no personalized content", () => {
+    expect(getProduktkortList("nb", undefined)).toBeUndefined();
+  });
+
+  it("should sort produktkort codes and map them to product properties", () => {
+    const content = {
+      produktkort: ["FOR", "DAG"],
+    } as PersonalizedContent;
+
+    const result = getProduktkortList("nb", content);
+
+    expect(result?.map((p) => p.produktnavn)).toEqual(["dagpenger", "foreldrepenger"]);
+  });
+});

--- a/src/features/dokumenter/dokument/Dokument.astro
+++ b/src/features/dokumenter/dokument/Dokument.astro
@@ -25,7 +25,7 @@ const avsender = setAvsenderMottaker(dokument);
         {avsender ? dato + " - " + avsender : dato}
       </BodyShort>
     </div>
-    <Chevron className={styles.chevron} fontSize="20px" />
+    <Chevron className={styles.chevron} aria-hidden={true} fontSize="20px" />
   </a>
 </li>
 

--- a/src/features/dokumenter/dokument/dokumentUtils.test.ts
+++ b/src/features/dokumenter/dokument/dokumentUtils.test.ts
@@ -1,0 +1,30 @@
+import type { DokumentType } from "@src/features/dokumenter/dokumenterTypes";
+import { describe, expect, it } from "vitest";
+import { formatDateMonth, setAvsenderMottaker } from "./dokumentUtils";
+
+const dokument = (overrides: Partial<DokumentType> = {}): DokumentType => ({
+  tittel: "Vedtak om dagpenger",
+  opprettet: "2024-06-17",
+  dokumentInfoId: "doc-1",
+  journalpostId: "jp-1",
+  temakode: "DAG",
+  avsender: null,
+  mottaker: null,
+  ...overrides,
+});
+
+describe("formatDateMonth", () => {
+  it("should format the date as 'day. month year' in Norwegian", () => {
+    expect(formatDateMonth("2024-06-17")).toBe("17. juni 2024");
+  });
+});
+
+describe("setAvsenderMottaker", () => {
+  it("should return the avsender when it is set", () => {
+    expect(setAvsenderMottaker(dokument({ avsender: "Nav" }))).toBe("Nav");
+  });
+
+  it("should fall back to the mottaker when there is no avsender", () => {
+    expect(setAvsenderMottaker(dokument({ avsender: null, mottaker: "Ola" }))).toBe("Ola");
+  });
+});

--- a/src/features/innboks/InnboksTag.test.tsx
+++ b/src/features/innboks/InnboksTag.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import InnboksTag from "./InnboksTag";
+
+describe("InnboksTag", () => {
+  it("should render the singular text for exactly one new message", () => {
+    render(<InnboksTag innbokser={1} locale="nb" />);
+
+    expect(screen.getByText("1 ny melding")).toBeInTheDocument();
+  });
+
+  it("should render the plural text for several new messages", () => {
+    render(<InnboksTag innbokser={3} locale="nb" />);
+
+    expect(screen.getByText("3 nye meldinger")).toBeInTheDocument();
+  });
+
+  it("should render the empty-state text when there are no new messages", () => {
+    render(<InnboksTag innbokser={0} locale="nb" />);
+
+    expect(screen.getByText("Ingen nye meldinger")).toBeInTheDocument();
+  });
+
+  it("should render the English text for the given locale", () => {
+    render(<InnboksTag innbokser={2} locale="en" />);
+
+    expect(screen.getByText("2 new messages")).toBeInTheDocument();
+  });
+});

--- a/src/features/innloggede-tjenester/link/LinkWithAmplitude.test.tsx
+++ b/src/features/innloggede-tjenester/link/LinkWithAmplitude.test.tsx
@@ -1,0 +1,41 @@
+import type { Lenke } from "@src/features/innloggede-tjenester/innloggedeTjenesterUrls";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LinkWithAmplitude from "./LinkWithAmplitude";
+
+const logEvent = vi.fn();
+vi.mock("@src/shared/utils/client/umami.ts", () => ({
+  logEvent: (...args: unknown[]) => logEvent(...args),
+}));
+
+const link: Lenke = {
+  nb: "Aktivitetsplan",
+  nn: "Aktivitetsplan",
+  en: "Activity plan",
+  url: {
+    nb: "https://aktivitetsplan.nav.no/nb",
+    nn: "https://aktivitetsplan.nav.no/nn",
+    en: "https://aktivitetsplan.nav.no/en",
+  },
+};
+
+afterEach(() => {
+  logEvent.mockReset();
+});
+
+describe("LinkWithAmplitude", () => {
+  it("should render the link text and href for the given locale", () => {
+    render(<LinkWithAmplitude link={link} locale="en" />);
+
+    const anchor = screen.getByRole("link", { name: "Activity plan" });
+    expect(anchor).toHaveAttribute("href", "https://aktivitetsplan.nav.no/en");
+  });
+
+  it("should log an analytics event when the link is clicked", () => {
+    render(<LinkWithAmplitude link={link} locale="nb" />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Aktivitetsplan" }));
+
+    expect(logEvent).toHaveBeenCalledWith("innloggede-tjenester-lenke", "innloggede-tjenester", "Aktivitetsplan");
+  });
+});

--- a/src/features/utbetaling/utbetalingUtils.test.ts
+++ b/src/features/utbetaling/utbetalingUtils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { Utbetaling, UtbetalingData } from "./utbetalingTypes";
+import { formatToReadableDate, isIngen, isKommende, isList, isTidligere } from "./utbetalingUtils";
+
+const utbetalingData = (id: string): UtbetalingData => ({
+  utbetaling: 1000,
+  dato: "2024-06-17",
+  ytelse: "Dagpenger",
+  kontonummer: "12345678901",
+  id,
+});
+
+const utbetaling = (kommende: number, siste: number): Utbetaling => ({
+  kommendeUtbetalinger: Array.from({ length: kommende }, (_, i) => utbetalingData(`k${i}`)),
+  sisteUtbetalinger: Array.from({ length: siste }, (_, i) => utbetalingData(`s${i}`)),
+});
+
+describe("formatToReadableDate", () => {
+  it("should format the date as 'day. month' in Norwegian", () => {
+    expect(formatToReadableDate("2024-06-17").trim()).toBe("17. juni");
+  });
+});
+
+describe("isIngen", () => {
+  it("should be true when there are no payments at all", () => {
+    expect(isIngen(utbetaling(0, 0))).toBe(true);
+  });
+
+  it("should be false when there is at least one payment", () => {
+    expect(isIngen(utbetaling(1, 0))).toBe(false);
+  });
+});
+
+describe("isKommende", () => {
+  it("should be true for exactly one upcoming and no past payment", () => {
+    expect(isKommende(utbetaling(1, 0))).toBe(true);
+  });
+
+  it("should be false when there is also a past payment", () => {
+    expect(isKommende(utbetaling(1, 1))).toBe(false);
+  });
+});
+
+describe("isTidligere", () => {
+  it("should be true for exactly one past and no upcoming payment", () => {
+    expect(isTidligere(utbetaling(0, 1))).toBe(true);
+  });
+
+  it("should be false when there is also an upcoming payment", () => {
+    expect(isTidligere(utbetaling(1, 1))).toBe(false);
+  });
+});
+
+describe("isList", () => {
+  it("should be true when there are two or more payments combined", () => {
+    expect(isList(utbetaling(1, 1))).toBe(true);
+    expect(isList(utbetaling(0, 2))).toBe(true);
+  });
+
+  it("should be false when there is at most one payment", () => {
+    expect(isList(utbetaling(1, 0))).toBe(false);
+    expect(isList(utbetaling(0, 0))).toBe(false);
+  });
+});

--- a/src/shared/feilmelding/Feilmelding.test.tsx
+++ b/src/shared/feilmelding/Feilmelding.test.tsx
@@ -1,0 +1,33 @@
+import { isErrorAtom } from "@src/shared/store/store";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import Feilmelding from "./Feilmelding";
+import { feilmeldingText } from "./feilmeldingText";
+
+beforeEach(() => {
+  isErrorAtom.set(false);
+});
+
+describe("Feilmelding", () => {
+  it("should render nothing while there is no error", () => {
+    const { container } = render(<Feilmelding locale="nb" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render the error alert when the error atom is set", () => {
+    isErrorAtom.set(true);
+
+    render(<Feilmelding locale="nb" />);
+
+    expect(screen.getByText(feilmeldingText.feilmelding.nb)).toBeInTheDocument();
+  });
+
+  it("should render the alert text for the given locale", () => {
+    isErrorAtom.set(true);
+
+    render(<Feilmelding locale="en" />);
+
+    expect(screen.getByText(feilmeldingText.feilmelding.en)).toBeInTheDocument();
+  });
+});

--- a/src/shared/store/store.test.ts
+++ b/src/shared/store/store.test.ts
@@ -1,0 +1,18 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { isErrorAtom, setIsError } from "./store";
+
+describe("isErrorAtom", () => {
+  beforeEach(() => {
+    isErrorAtom.set(false);
+  });
+
+  it("should default to false", () => {
+    expect(isErrorAtom.value).toBe(false);
+  });
+
+  it("setIsError should flip the atom to true", () => {
+    setIsError();
+
+    expect(isErrorAtom.value).toBe(true);
+  });
+});

--- a/src/shared/utils/client/api.test.ts
+++ b/src/shared/utils/client/api.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetcher } from "./api";
+
+describe("fetcher", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should GET the path and return the parsed json", async () => {
+    const payload = { hello: "world" };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetcher({ path: "/varsler" });
+
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith("/varsler", { method: "GET" });
+  });
+
+  it("should merge caller options over the defaults", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetcher({
+      path: "/varsler",
+      options: { credentials: "include" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/varsler", {
+      method: "GET",
+      credentials: "include",
+    });
+  });
+
+  it("should throw when the response is not ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetcher({ path: "/varsler" })).rejects.toThrow("Fetch request failed");
+  });
+});

--- a/src/shared/utils/server/error.test.ts
+++ b/src/shared/utils/server/error.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { MultiStatusError } from "./error";
+
+describe("MultiStatusError", () => {
+  it("should be an Error with the given message", () => {
+    const error = new MultiStatusError("partial failure", null);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("partial failure");
+  });
+
+  it("should expose the partial data it was constructed with", () => {
+    const partialData = { ok: ["a"], failed: ["b"] };
+
+    const error = new MultiStatusError("partial failure", partialData);
+
+    expect(error.partialData).toEqual(partialData);
+  });
+});

--- a/src/shared/utils/server/fetch.test.ts
+++ b/src/shared/utils/server/fetch.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MultiStatusError } from "./error";
+import { fetchData, fetchMicrofrontend } from "./fetch";
+
+const url = "http://localhost:3000/navn";
+const token = "obo-token";
+
+describe("fetchData", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should GET the url with a bearer token and return the parsed json", async () => {
+    const payload = { navn: "Navn Navnesen", ident: "1234" };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchData(token, url);
+
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  });
+
+  it("should throw a MultiStatusError carrying the partial data on a 207 response", async () => {
+    const partial = { delivered: ["a"], failed: ["b"] };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 207,
+      json: async () => partial,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchData(token, url)).rejects.toThrow(MultiStatusError);
+    await expect(fetchData(token, url)).rejects.toMatchObject({
+      partialData: partial,
+    });
+  });
+
+  it("should throw when the response is not ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchData(token, url)).rejects.toThrow("Http error with status: 500");
+  });
+});
+
+describe("fetchMicrofrontend", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should GET the url with a bearer token and return the response text", async () => {
+    const html = "<div>microfrontend</div>";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => html,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchMicrofrontend(token, url);
+
+    expect(result).toBe(html);
+    expect(fetchMock).toHaveBeenCalledWith(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  });
+
+  it("should throw when the response is not ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchMicrofrontend(token, url)).rejects.toThrow("Http error with status: 503");
+  });
+});

--- a/src/shared/utils/server/locale.test.ts
+++ b/src/shared/utils/server/locale.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { getLocale } from "./locale";
+
+describe("getLocale", () => {
+  it("should return the provided locale when it is set", () => {
+    expect(getLocale("nn")).toBe("nn");
+    expect(getLocale("en")).toBe("en");
+    expect(getLocale("nb")).toBe("nb");
+  });
+
+  it("should fall back to 'nb' when the locale is undefined", () => {
+    expect(getLocale(undefined)).toBe("nb");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from "node:url";
+import { getViteConfig } from "astro/config";
+
+export default getViteConfig({
+  resolve: {
+    alias: {
+      "@src": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  // Astro's helper accepts this at runtime, but its type here doesn't include Vitest's augmentation.
+  // @ts-expect-error Vitest config
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Beskrivelse

Min side hadde ingen automatiserte tester. Denne PR-en innfører et komplett testoppsett – Vitest for enhetstester og Playwright for e2e – og kobler det på i CI slik at testene kjører før deploy. Gir et trygt sikkerhetsnett rundt SSR-komposisjonen og feature-slicene.

## Endringer

- `vitest.config.ts`, `vitest.setup.ts`, `package.json`: Vitest (jsdom) + `test`/`test:watch`/`test:coverage`-scripts og dev-avhengigheter
- `src/**/*.test.ts(x)`: 50 enhetstester for utils, store og React-komponenter (utbetaling, varsler, dokumenter, din-oversikt, innboks, innloggede tjenester, feilmelding, fetch/error/locale/api)
- `playwright.config.ts`, `e2e/`: Playwright e2e med `MinSidePage` page object og 23 tester – innhold per feature-slice (din oversikt, utbetaling, innboks, dokumenter, varsler/utkast, aktuelt, innloggede tjenester), lenker, responsivt (mobil/desktop), 404 og axe-tilgjengelighet (WCAG 2 A/AA)
- `.github/workflows/deploy-dev.yaml`, `deploy-main.yaml`: kjør enhets- og e2e-tester før build
- `.gitignore`: ignorer Playwright-artefakter (`test-results/`, `playwright-report/`, `playwright/.cache/`)
- `src/features/dokumenter/dokument/Dokument.astro`: marker dekorativt chevron-ikon med `aria-hidden` (fanges av axe-testen)

## Issue

Ingen tilknyttet issue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`astro check` via pre-push, `biome check` på endrede filer via pre-commit)
- [x] Endringene er testet (automatisk): 50 enhetstester (`pnpm test`) og 23 e2e-tester (`CI=true pnpm exec playwright test`) – alle grønne
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

<sub>Verifisert lokalt: 50/50 unit + 23/23 e2e. Mock-data og `NODE_ENV=development` (auth bypass) brukes for e2e.</sub>