### PR TITLE
feat: enable vite build sourcemaps

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,11 @@ export default defineConfig({
   build: {
     assetsPrefix: "https://cdn.nav.no/min-side/tms-min-side",
   },
+  vite: {
+    build: {
+      sourcemap: true,
+    },
+  },
   integrations: [
     react(),
     {


### PR DESCRIPTION
## Beskrivelse

Aktiverer source maps for produksjonsbygget slik at feilmeldinger i nettleser-devtools og observability-verktoy kan peke tilbake til original kildekode.

## Endringer

- `astro.config.mjs`: Lagt til `vite.build.sourcemap: true` for a generere source maps under bygg.

## Issue

N/A

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)