### PR TITLE
refactor: use if guard for validation.ok in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,10 @@ import { sequence } from "astro/middleware";
 
 export const onRequest = sequence(authenticate(), async (context, next) => {
   const { validation } = context.locals;
-  context.locals.isSubstantial = validation?.ok && validation.payload.acr === "idporten-loa-substantial";
+
+  if (validation?.ok) {
+    context.locals.isSubstantial = validation.payload.acr === "idporten-loa-substantial";
+  }
 
   return next();
 });


### PR DESCRIPTION
## Beskrivelse

Refaktorerer `src/middleware.ts` til å bruke en eksplisitt `if`-guard i stedet for kort-slutnings-`&&`-uttrykk for å sjekke `validation.ok`. Dette gir bedre lesbarhet og lar TypeScript utføre type narrowing inne i blokken.

## Endringer

- `src/middleware.ts`: Erstatter `validation?.ok && validation.payload.acr === "..."` med en `if (validation?.ok)` guard som setter `isSubstantial` inne i blokken.

## Issue

N/A

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)