### PR TITLE
docs: legg til påkrevde skills for commits og PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,6 +103,11 @@ Bruk begreper fra `docs/UBIQUITOUS_LANGUAGE.md` konsekvent i navn/tekster:
 
 - `Innbygger`, `Din oversikt`, `Alert island`, `Varsel` (ikke bland med `Melding` fra Innboks-kontekst), `Utkast`, `Ytelse`.
 
+### Skills som alltid skal brukes
+
+- **Commits**: Bruk alltid `/conventional-commit`-skillen ved commits og commit-meldinger.
+- **Pull requests**: Bruk alltid `/pull-request`-skillen ved oppretting eller oppdatering av pull requests.
+
 ### Instruksjonsfiler som gjelder ved endringer
 
 - React/TSX: følg `.github/instructions/accessibility.instructions.md` (Aksel-komponenter + semantikk).


### PR DESCRIPTION
## Beskrivelse

Sikrer at Copilot alltid bruker `/conventional-commit` ved commits og `/pull-request` ved PR-oppretting/-oppdatering i dette repoet, ved å legge til instruksjoner i den repo-globale copilot-instructions-filen.

## Endringer

- `.github/copilot-instructions.md`: Ny seksjon "Skills som alltid skal brukes" som instruerer om obligatorisk bruk av de to skillene.

## Issue

N/A

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)