### PR TITLE
ci(deps): legg til Digestabot-workflow

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,24 @@
+name: "Check for newer image versions"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 08:00 UTC.
+    - cron: "0 8 * * 1"
+
+jobs:
+  digest-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: navikt/digestabot@3302a753e533ceb9ec216de7f78345436cd636e3 # v1.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          team: min-side


### PR DESCRIPTION
## Beskrivelse

Legger til automatisk overvaking av nyere container-imageversjoner, slik at avhengighetsoppdateringer kan opprettes jevnlig av Digestabot.

## Endringer

- Kjører Digestabot hver mandag kl. 08:00 UTC og ved manuell oppstart
- Bruker SHA-pinnede actions, minimale skrivetilganger og tidsavbrudd på jobben
- Konfigurerer oppdateringer for teamet `min-side`

## Issue

N/A

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)