### PR TITLE
build(docker): bruk Chainguard Node 24-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs24-debian12
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim@sha256:8b0b8c0d78166534d392bfb670f96fa6d443cec16169481788aa1ed27dfc4a7d
 
 WORKDIR /usr/src/app
 COPY ./dist ./dist


### PR DESCRIPTION
## Beskrivelse

Bytter runtime-imaget fra Google Distroless til det ønskede, digest-pinnede Node 24 slim-imaget fra Navs Chainguard-register. Dette følger samme oppsett som `tms-utkast-frontend`.

## Endringer

- `Dockerfile`: Bruk `europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:24-slim` med oppgitt SHA-256-digest.

## Issue

N/A

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)